### PR TITLE
Markdown materials database

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,6 @@ dependencies:
   - pytest
   - pyside
   - future
-  - pytablewriter
+  - pip:
+    - pytablewriter
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,5 @@ dependencies:
   - pytest
   - pyside
   - future
+  - pytablewriter
+

--- a/materials.md
+++ b/materials.md
@@ -1,0 +1,78 @@
+# Materials database
+
+## Metals
+|   metal    |work function [eV]|
+|------------|-----------------:|
+|Al          |             4.280|
+|Au          |             5.285|
+|NbTiN       |             4.280|
+|degenDopedSi|             4.050|
+
+Sources:
+* Wikipedia
+* Ioffe Institute, http://www.ioffe.ru/SVA/NSM/Semicond/Si/basic.html
+
+## Dielectrics
+|dielectric|relative permittivity|
+|----------|--------------------:|
+|Al2O3     |                  9.0|
+|HfO2      |                 25.0|
+|Si3N4     |                  7.0|
+|SiO2      |                  3.9|
+|ZrO2      |                 25.0|
+|air       |                  1.0|
+
+Sources:
+* Robertson, EPJAP 28, 265 (2004): High dielectric constant oxides,
+  https://doi.org/10.1051/epjap:2004206
+* Biercuk et al., APL 83, 2405 (2003), Low-temperature atomic-layer-deposition lift-off method
+  for microelectronic and nanoelectronic applications, https://doi.org/10.1063/1.1612904
+* Yota et al.,  JVSTA 31, 01A134 (2013), Characterization of atomic layer deposition HfO2,
+  Al2O3, and plasma-enhanced chemical vapor deposition Si3N4 as metal-insulator-metal
+  capacitor dielectric for GaAs HBT technology, https://doi.org/10.1116/1.4769207
+
+## Semiconductors
+|                                                         | AlAs | AlSb  | GaAs | GaSb | InAs |  InP  | InSb |  Si  |
+|---------------------------------------------------------|-----:|------:|-----:|-----:|-----:|------:|-----:|-----:|
+|relative permittivity                                    |10.060|11.0000|13.100|15.700|15.150|12.5000|16.800|11.700|
+|electron mass [m_e]                                      | 0.150| 0.1400| 0.067| 0.039| 0.026| 0.0795| 0.013| 1.108|
+|electron affinity $\chi$ [eV]                            | 2.970|       | 4.070| 4.060| 4.900| 4.3800| 4.590| 4.050|
+|direct band gap $E_g(\Gamma)$ [eV]                       | 3.099| 2.3860| 1.519| 0.812| 0.417| 1.4236| 0.235| 3.480|
+|valence band offset w.r.t. InSb [eV]                     |-1.330|-0.4100|-0.800|-0.030|-0.590|-0.9400| 0.000|      |
+|spin-orbit splitting $\Delta_{so}$ [eV]                  | 0.280| 0.6760| 0.341| 0.760| 0.390| 0.1080| 0.810| 0.044|
+|interband matrix element $E_P$ [eV]                      |21.100|18.7000|28.800|27.000|21.500|20.7000|23.300|      |
+|Luttinger parameter $\gamma_1$                           | 3.760| 5.1800| 6.980|13.400|20.000| 5.0800|34.800| 4.280|
+|Luttinger parameter $\gamma_2$                           | 0.820| 1.1900| 2.060| 4.700| 8.500| 1.6000|15.500| 0.339|
+|Luttinger parameter $\gamma_3$                           | 1.420| 1.9700| 2.930| 6.000| 9.200| 2.1000|16.500| 1.446|
+|charge neutrality level [from VB edge, in eV]            |      |       |      |      | 0.577|       | 0.118|      |
+|density of surface states [10$^{12}$ cm$^{-2}$ eV$^(-1)$]|      |       |      |      | 3.000|       | 3.000|      |
+
+Sources:
+* [Vurgaftman] Vurgaftman et al., APR 89, 5815 (2001): Band parameters for III-V compound
+  semiconductors and their alloys,  https://doi.org/10.1063/1.1368156
+* [Heedt] Heedt, et al. Resolving ambiguities in nanowire field-effect transistor
+  characterization. Nanoscale 7, 18188-18197, 2015. https://doi.org/10.1039/c5nr03608a
+* [Monch] Monch, Semiconductor Surfaces and Interfaces, 3rd Edition, Springer (2001).
+* [ioffe.ru] http://www.ioffe.ru/SVA/NSM/Semicond
+
+### Bowing parameters
+
+Properties of an alloy $A_{1-x} B_x$ are computed by quadratic interpolation between the
+endpoints if there is a corresponding bowing parameter for this property and alloy.
+Otherwise linear interpolation is employed. The quadratic interpolation formula uses the
+convention
+    $O(A_{1-x} B_x) = (1-x) O(A) + x O(B) - x(1-x) O_{AB}$,
+with the bowing parameter $O_{AB}$.
+
+|                                       |(AlAs, GaAs)|(AlAs, InAs)|(GaAs, InAs)|(GaSb, InSb)|(InAs, InSb)|
+|---------------------------------------|-----------:|-----------:|-----------:|-----------:|-----------:|
+|electron mass [m_e]                    |           0|      0.0490|      0.0091|      0.0092|       0.035|
+|direct band gap $E_g(\Gamma)$ [eV]     |            |      0.7000|      0.4770|      0.4250|       0.670|
+|valence band offset w.r.t. InSb [eV]   |            |     -0.6400|     -0.3800|            |            |
+|spin-orbit splitting $\Delta_{so}$ [eV]|            |      0.1500|      0.1500|      0.1000|       1.200|
+|interband matrix element $E_P$ [eV]    |            |            |     -1.4800|            |            |
+
+Sources:
+* [Vurgaftman] Vurgaftman et al., APR 89, 5815 (2001): Band parameters for III-V compound
+  semiconductors and their alloys,  https://doi.org/10.1063/1.1368156
+

--- a/qmt/materials.json
+++ b/qmt/materials.json
@@ -1,1 +1,194 @@
-{"Al": {"type": "metal", "relativePermittivity": 1000, "electronMass": 1.0, "workFunction": 4280.0}, "Au": {"type": "metal", "relativePermittivity": 1000, "electronMass": 1.0, "workFunction": 5285.0}, "degenDopedSi": {"type": "metal", "relativePermittivity": 1000, "electronMass": 1.0, "workFunction": 4050.0}, "NbTiN": {"type": "metal", "relativePermittivity": 1000, "electronMass": 1.0, "workFunction": 4280.0}, "air": {"type": "dielectric", "relativePermittivity": 1, "electronMass": 1.0}, "Si3N4": {"type": "dielectric", "relativePermittivity": 7.0, "electronMass": 1.0}, "SiO2": {"type": "dielectric", "relativePermittivity": 3.9, "electronMass": 1.0}, "HfO2": {"type": "dielectric", "relativePermittivity": 25.0, "electronMass": 1.0}, "Al2O3": {"type": "dielectric", "relativePermittivity": 9.0, "electronMass": 1.0}, "GaAs": {"type": "semi", "relativePermittivity": 13.1, "electronMass": 0.067, "electronAffinity": 4070.0, "directBandGap": 1519.0, "valenceBandOffset": -800.0, "spinOrbitSplitting": 341.0, "interbandMatrixElement": 28800.0, "luttingerGamma1": 6.98, "luttingerGamma2": 2.06, "luttingerGamma3": 2.93}, "AlAs": {"type": "semi", "relativePermittivity": 10.06, "electronMass": 0.15, "electronAffinity": 2970.0, "directBandGap": 3099, "valenceBandOffset": -1330.0, "spinOrbitSplitting": 280.0, "interbandMatrixElement": 21100.0, "luttingerGamma1": 3.76, "luttingerGamma2": 0.82, "luttingerGamma3": 1.42}, "InAs": {"type": "semi", "relativePermittivity": 15.15, "electronMass": 0.026, "electronAffinity": 4900.0, "directBandGap": 417.0, "valenceBandOffset": -590.0, "spinOrbitSplitting": 390.0, "interbandMatrixElement": 21500.0, "luttingerGamma1": 20.0, "luttingerGamma2": 8.5, "luttingerGamma3": 9.2, "chargeNeutralityLevel": 577.0, "surfaceChargeDensity": 3000000000000.0}, "GaSb": {"type": "semi", "relativePermittivity": 15.7, "electronMass": 0.039, "electronAffinity": 4060.0, "directBandGap": 812.0, "valenceBandOffset": -30.0, "spinOrbitSplitting": 760.0, "interbandMatrixElement": 27000.0, "luttingerGamma1": 13.4, "luttingerGamma2": 4.7, "luttingerGamma3": 6.0}, "AlSb": {"type": "semi", "relativePermittivity": 11.0, "electronMass": 0.14, "directBandGap": 2386.0, "valenceBandOffset": -410.0, "spinOrbitSplitting": 676.0, "interbandMatrixElement": 18700.0, "luttingerGamma1": 5.18, "luttingerGamma2": 1.19, "luttingerGamma3": 1.97}, "InSb": {"type": "semi", "relativePermittivity": 16.8, "electronMass": 0.0135, "electronAffinity": 4590.0, "directBandGap": 235.0, "valenceBandOffset": 0.0, "spinOrbitSplitting": 810.0, "interbandMatrixElement": 23300.0, "luttingerGamma1": 34.8, "luttingerGamma2": 15.5, "luttingerGamma3": 16.5, "chargeNeutralityLevel": 117.5, "surfaceChargeDensity": 3000000000000.0}, "InP": {"type": "semi", "relativePermittivity": 12.5, "electronMass": 0.0795, "electronAffinity": 4380.0, "directBandGap": 1423.6, "valenceBandOffset": -940.0, "spinOrbitSplitting": 108.0, "interbandMatrixElement": 20700.0, "luttingerGamma1": 5.08, "luttingerGamma2": 1.6, "luttingerGamma3": 2.1}, "Si": {"type": "semi", "relativePermittivity": 11.7, "electronMass": 1.1079316513508928, "electronAffinity": 4050.0, "directBandGap": 3480.0, "spinOrbitSplitting": 44.0, "luttingerGamma1": 4.28, "luttingerGamma2": 0.339, "luttingerGamma3": 1.446}, "__bowing_parameters": {"('GaAs', 'InAs')": {"type": "semi", "electronMass": 0.0091, "directBandGap": 477.0, "valenceBandOffset": -380.0, "spinOrbitSplitting": 150.0, "interbandMatrixElement": -1480.0}, "('AlAs', 'GaAs')": {"type": "semi", "electronMass": 0.0}, "('AlAs', 'InAs')": {"type": "semi", "electronMass": 0.049, "directBandGap": 700.0, "valenceBandOffset": -640.0, "spinOrbitSplitting": 150.0}, "('GaSb', 'InSb')": {"type": "semi", "electronMass": 0.0092, "directBandGap": 425.0, "spinOrbitSplitting": 100.0}, "('InAs', 'InSb')": {"type": "semi", "electronMass": 0.035, "directBandGap": 670.0, "spinOrbitSplitting": 1200.0}}}
+{
+    "Al": {
+        "electronMass": 1.0,
+        "relativePermittivity": 1000,
+        "type": "metal",
+        "workFunction": 4280.0
+    },
+    "Al2O3": {
+        "electronMass": 1.0,
+        "relativePermittivity": 9.0,
+        "type": "dielectric"
+    },
+    "AlAs": {
+        "directBandGap": 3099,
+        "electronAffinity": 2970.0,
+        "electronMass": 0.15,
+        "interbandMatrixElement": 21100.0,
+        "luttingerGamma1": 3.76,
+        "luttingerGamma2": 0.82,
+        "luttingerGamma3": 1.42,
+        "relativePermittivity": 10.06,
+        "spinOrbitSplitting": 280.0,
+        "type": "semi",
+        "valenceBandOffset": -1330.0
+    },
+    "AlSb": {
+        "directBandGap": 2386.0,
+        "electronMass": 0.14,
+        "interbandMatrixElement": 18700.0,
+        "luttingerGamma1": 5.18,
+        "luttingerGamma2": 1.19,
+        "luttingerGamma3": 1.97,
+        "relativePermittivity": 11.0,
+        "spinOrbitSplitting": 676.0,
+        "type": "semi",
+        "valenceBandOffset": -410.0
+    },
+    "Au": {
+        "electronMass": 1.0,
+        "relativePermittivity": 1000,
+        "type": "metal",
+        "workFunction": 5285.0
+    },
+    "GaAs": {
+        "directBandGap": 1519.0,
+        "electronAffinity": 4070.0,
+        "electronMass": 0.067,
+        "interbandMatrixElement": 28800.0,
+        "luttingerGamma1": 6.98,
+        "luttingerGamma2": 2.06,
+        "luttingerGamma3": 2.93,
+        "relativePermittivity": 13.1,
+        "spinOrbitSplitting": 341.0,
+        "type": "semi",
+        "valenceBandOffset": -800.0
+    },
+    "GaSb": {
+        "directBandGap": 812.0,
+        "electronAffinity": 4060.0,
+        "electronMass": 0.039,
+        "interbandMatrixElement": 27000.0,
+        "luttingerGamma1": 13.4,
+        "luttingerGamma2": 4.7,
+        "luttingerGamma3": 6.0,
+        "relativePermittivity": 15.7,
+        "spinOrbitSplitting": 760.0,
+        "type": "semi",
+        "valenceBandOffset": -30.0
+    },
+    "HfO2": {
+        "electronMass": 1.0,
+        "relativePermittivity": 25.0,
+        "type": "dielectric"
+    },
+    "InAs": {
+        "chargeNeutralityLevel": 577.0,
+        "directBandGap": 417.0,
+        "electronAffinity": 4900.0,
+        "electronMass": 0.026,
+        "interbandMatrixElement": 21500.0,
+        "luttingerGamma1": 20.0,
+        "luttingerGamma2": 8.5,
+        "luttingerGamma3": 9.2,
+        "relativePermittivity": 15.15,
+        "spinOrbitSplitting": 390.0,
+        "surfaceChargeDensity": 3000000000000.0,
+        "type": "semi",
+        "valenceBandOffset": -590.0
+    },
+    "InP": {
+        "directBandGap": 1423.6,
+        "electronAffinity": 4380.0,
+        "electronMass": 0.0795,
+        "interbandMatrixElement": 20700.0,
+        "luttingerGamma1": 5.08,
+        "luttingerGamma2": 1.6,
+        "luttingerGamma3": 2.1,
+        "relativePermittivity": 12.5,
+        "spinOrbitSplitting": 108.0,
+        "type": "semi",
+        "valenceBandOffset": -940.0
+    },
+    "InSb": {
+        "chargeNeutralityLevel": 117.5,
+        "directBandGap": 235.0,
+        "electronAffinity": 4590.0,
+        "electronMass": 0.0135,
+        "interbandMatrixElement": 23300.0,
+        "luttingerGamma1": 34.8,
+        "luttingerGamma2": 15.5,
+        "luttingerGamma3": 16.5,
+        "relativePermittivity": 16.8,
+        "spinOrbitSplitting": 810.0,
+        "surfaceChargeDensity": 3000000000000.0,
+        "type": "semi",
+        "valenceBandOffset": 0.0
+    },
+    "NbTiN": {
+        "electronMass": 1.0,
+        "relativePermittivity": 1000,
+        "type": "metal",
+        "workFunction": 4280.0
+    },
+    "Si": {
+        "directBandGap": 3480.0,
+        "electronAffinity": 4050.0,
+        "electronMass": 1.1079316513508928,
+        "luttingerGamma1": 4.28,
+        "luttingerGamma2": 0.339,
+        "luttingerGamma3": 1.446,
+        "relativePermittivity": 11.7,
+        "spinOrbitSplitting": 44.0,
+        "type": "semi"
+    },
+    "Si3N4": {
+        "electronMass": 1.0,
+        "relativePermittivity": 7.0,
+        "type": "dielectric"
+    },
+    "SiO2": {
+        "electronMass": 1.0,
+        "relativePermittivity": 3.9,
+        "type": "dielectric"
+    },
+    "ZrO2": {
+        "electronMass": 1.0,
+        "relativePermittivity": 25.0,
+        "type": "dielectric"
+    },
+    "__bowing_parameters": {
+        "('AlAs', 'GaAs')": {
+            "electronMass": 0.0,
+            "type": "semi"
+        },
+        "('AlAs', 'InAs')": {
+            "directBandGap": 700.0,
+            "electronMass": 0.049,
+            "spinOrbitSplitting": 150.0,
+            "type": "semi",
+            "valenceBandOffset": -640.0
+        },
+        "('GaAs', 'InAs')": {
+            "directBandGap": 477.0,
+            "electronMass": 0.0091,
+            "interbandMatrixElement": -1480.0,
+            "spinOrbitSplitting": 150.0,
+            "type": "semi",
+            "valenceBandOffset": -380.0
+        },
+        "('GaSb', 'InSb')": {
+            "directBandGap": 425.0,
+            "electronMass": 0.0092,
+            "spinOrbitSplitting": 100.0,
+            "type": "semi"
+        },
+        "('InAs', 'InSb')": {
+            "directBandGap": 670.0,
+            "electronMass": 0.035,
+            "spinOrbitSplitting": 1200.0,
+            "type": "semi"
+        }
+    },
+    "air": {
+        "electronMass": 1.0,
+        "relativePermittivity": 1,
+        "type": "dielectric"
+    },
+    "degenDopedSi": {
+        "electronMass": 1.0,
+        "relativePermittivity": 1000,
+        "type": "metal",
+        "workFunction": 4050.0
+    }
+}


### PR DESCRIPTION
Write materials database to a nicely formatted markdown file in addition to json.
The purpose is to serve as an easily human-readable reference for the parameters we are using. Additionally, the json file is now written with line breaks, indendation, and in alphabetic order so that diffs are easier to understand.