### PR TITLE
Add nonEmpty check to union

### DIFF
--- a/qmt/freecad/geomUtils.py
+++ b/qmt/freecad/geomUtils.py
@@ -100,7 +100,11 @@ def genUnion(objList, consumeInputs=False):
         return returnObj
     else:
         union = doc.addObject("Part::MultiFuse")
-        union.Shapes = objList
+        nonZeroList = []
+        for obj in objList:
+            if isNonempty(obj):
+                nonZeroList += [obj]
+        union.Shapes = nonZeroList
         doc.recompute()
         unionDupe = copy(union)
         doc.removeObject(union.Name)
@@ -201,6 +205,14 @@ def checkOverlap(objList):
         overlap = True
     delete(intObj)
     return overlap
+
+def isNonempty(obj):
+    ''' Checks if an object is nonempty (returns True) or empty (returns False).
+    '''
+    if len(obj.Shape.Vertexes) == 0:
+        return False
+    else:
+        return True
 
 
 def extrudeBetween(sketch, zMin, zMax):


### PR DESCRIPTION
Union would fail if it encountered  empty shapes. Added a check to see if shapes are empty and exclude them from the union.

Signed-off-by: John Gamble <johnkgamble@gmail.com>