### PR TITLE
Add fix for offsetting by a small value

### DIFF
--- a/qmt/freecad/objectConstruction.py
+++ b/qmt/freecad/objectConstruction.py
@@ -125,10 +125,13 @@ def makeSAG(sketch, zBot, zMid, zTop, tIn, tOut, offset=0.):
     c = a + 2 * offset  # height of the top part including the offset
     d = c / np.tan(alpha)  # horizontal width of the trianglular part of the top after offset
     f = offset / np.sin(alpha)  # horizontal shift in the triangular part of the top after an offset
-
+    
     sketchList = splitSketch(sketch)
     returnParts = []
     for tempSketch in sketchList:
+        #TODO: right now, if we try to taper the top of the SAG wire to a point, this
+        # breaks, since the offset of topSketch is empty. We should detect and handle this.
+        # For now, just make sure that the wire has a small flat top.
         botSketch = draftOffset(tempSketch, offset)  # the base of the wire
         midSketch = draftOffset(tempSketch, f + d - tIn)  # the base of the cap
         topSketch = draftOffset(tempSketch, -tIn + f)  # the top of the cap

--- a/qmt/freecad/sketchUtils.py
+++ b/qmt/freecad/sketchUtils.py
@@ -255,9 +255,10 @@ def makeIntoSketch(inputObj, sketchName=None):
     FreeCAD.ActiveDocument.recompute()
     return returnSketch
 
-def draftOffset(inputSketch,t):
+def draftOffset(inputSketch,t,tol=1e-8):
     ''' Attempt to offset the draft figure by a thickness t. Positive t is an
-    inflation, while negative t is a deflation.
+    inflation, while negative t is a deflation. tol sets how strict we should be when
+    checking if the offset worked.
     '''
     from qmt.freecad import extrude,copy,subtract,delete    
 
@@ -311,6 +312,8 @@ def draftOffset(inputSketch,t):
         returnSketch = copy(littleSketch)
     elif t>0 and bigSketch is not None:
         returnSketch = copy(bigSketch)
+    elif abs(t)<tol:
+        returnSketch = copy(inputSketch)
     else:
         raise ValueError('Failed to offset the sketch '+str(inputSketch.Name)+' by amount '+str(t))
     


### PR DESCRIPTION
If we have a sufficiently small offset, will now just return a copy of the original. This fixes some of the problems with SAG wire creation.

Signed-off-by: John Gamble <jgamble@basalt.guest.corp.microsoft.com>