### PR TITLE
print a warning when model cannot be opened, print nothing when succeeding

### DIFF
--- a/qmt/batchModel.py
+++ b/qmt/batchModel.py
@@ -703,7 +703,7 @@ class Model:
         try:
             with open(self.modelPath, 'r') as f:
                 modelDict = json.load(f)
-        except FileNotFoundError:
+        except IOError:  # change to FileNotFoundError when >Py3 only
             warnings.warn('Could not load: Model file {} does not exist.'.format(
                 self.modelPath))
             modelDict = self.genEmptyModelDict()

--- a/qmt/batchModel.py
+++ b/qmt/batchModel.py
@@ -701,15 +701,14 @@ class Model:
             the current state of modelDict will be wiped out and replaced by the
             loaded file.
         """
-        fileExists = os.path.isfile(self.modelPath)
-        if fileExists:
-            myFile = open(self.modelPath, 'r')
-            modelDict = json.load(myFile)
-            myFile.close()
-        else:
+        try:
+            with open(self.modelPath, 'r') as f:
+                modelDict = json.load(f)
+        except FileNotFoundError:
             warnings.warn('Could not load: Model file {} does not exist.'.format(
                 self.modelPath))
             modelDict = self.genEmptyModelDict()
+
         if updateModel:
             for subDictKey in self.modelDict:
                 modelDict[subDictKey].update(self.modelDict[subDictKey])

--- a/qmt/batchModel.py
+++ b/qmt/batchModel.py
@@ -2,10 +2,13 @@
 # Licensed under the MIT License.
 
 from __future__ import absolute_import, division, print_function
-import numpy as np
 import os
 import json
+import warnings
+
+import numpy as np
 from six import itervalues
+
 import qmt
 
 
@@ -14,8 +17,8 @@ class Model:
         """Class for creating, loading, and manipulating a json file that
         contains information about the model.
 
-        Keyword arguments
-        -----------------
+        Parameters
+        ----------
         modelPath : str, default None
             Path to the model json file. If initialized with None, should be set
             manually before loading/saving.
@@ -693,19 +696,18 @@ class Model:
         Parameters
         ----------
         updateModel : bool, default True
-        If true, whatever is currently in the modelDict will be added to the
-        loaded model on import. Repeated settings are overwritten. If false,
-        the current state of modelDict will be wiped out and replaced by the
-        loaded file.
+            If true, whatever is currently in the modelDict will be added to the
+            loaded model on import. Repeated settings are overwritten. If false,
+            the current state of modelDict will be wiped out and replaced by the
+            loaded file.
         """
         fileExists = os.path.isfile(self.modelPath)
         if fileExists:
-            print('Loading model file {}.'.format(self.modelPath))
             myFile = open(self.modelPath, 'r')
             modelDict = json.load(myFile)
             myFile.close()
         else:
-            print('Could not load: Model file {} does not exist.'.format(
+            warnings.warn('Could not load: Model file {} does not exist.'.format(
                 self.modelPath))
             modelDict = self.genEmptyModelDict()
         if updateModel:

--- a/qmt/batchModel.py
+++ b/qmt/batchModel.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from __future__ import absolute_import, division, print_function
-import os
 import json
 import warnings
 


### PR DESCRIPTION
When evaluating stuff in parallel or doing something multiple times, my terminal gets spammed with 100s of copies of the following line:
```
Loading model file side_gates/geo_/model.json.
```

This PR removes that print statement and only prints a warning when the file cannot be opened.