### PR TITLE
_solve_instance method of tasks now a static method.

### DIFF
--- a/qmt/tasks/basic/geometry.py
+++ b/qmt/tasks/basic/geometry.py
@@ -17,7 +17,7 @@ class Geometry1D(Task):
         """
         super(Geometry1D, self).__init__([], options, name)
 
-    def _solve_instance(self, input_result_list, current_options):
+    def _solve_instance(input_result_list, current_options):
         """
         :param list input_result_list: This is an empty list.
         :param dict current_options: The dictionary specifying parts from above.
@@ -41,7 +41,7 @@ class Geometry2D(Task):
         """
         super(Geometry2D, self).__init__([], options, name)
 
-    def _solve_instance(self, input_result_list, current_options):
+    def _solve_instance(input_result_list, current_options):
         """
         :param list input_result_list: This is an empty list.
         :param dict current_options: The dictionary specification from above.
@@ -71,7 +71,7 @@ class Geometry3D(Task):
         # for partDirective in options["part_dict"]:
         #     assert type(options["part_dict"][partDirective]) is Part3D
 
-    def _solve_instance(self, input_result_list, current_options):
+    def _solve_instance(input_result_list, current_options):
         """
         :param list input_result_list: This is an empty list.
         :param dict current_options: The dictionary specifying parts from above.

--- a/qmt/tasks/basic/reduce_dim.py
+++ b/qmt/tasks/basic/reduce_dim.py
@@ -23,7 +23,7 @@ class ReduceDim3D(Task):
         # if "parts" in options:
         #     for part in options["parts"]: assert type(part) is str
 
-    def _solve_instance(self, input_result_list, current_options):
+    def _solve_instance(input_result_list, current_options):
         """
         :param list input_result_list: This is a singleton list of a geo_3d object.
         :param dict current_options: The dictionary specifying parts from above.
@@ -52,7 +52,7 @@ class ReduceDim2D(Task):
         # if "parts" in options:
         #     for part in options["parts"]: assert type(part) is str
 
-    def _solve_instance(self, input_result_list, current_options):
+    def _solve_instance(input_result_list, current_options):
         """
         :param list input_result_list: This is a one-element list of a Geometry2D result.
         :param dict current_options: The dictionary specifying parts from above.

--- a/qmt/tasks/sweep.py
+++ b/qmt/tasks/sweep.py
@@ -1,7 +1,7 @@
 import dask
 import dask.distributed
 from six import iteritems
-
+import cloudpickle
 
 class SweepManager(object):
     """
@@ -530,6 +530,17 @@ class SweepTag(object):
         out = SweepTag(self.tag_name)
         out.tag_function = lambda x: abs(self.tag_function(x))
         return out
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Remove the unpicklable entries.
+        state['tag_function'] = cloudpickle.dumps(self.tag_function)
+        return state
+
+    def __setstate__(self, state):
+        # Restore instance attributes.
+        self.__dict__.update(state)
+        self.tag_function = cloudpickle.loads(state['tag_function'])
 
     def replace(self, value):
         return self.tag_function(value)

--- a/qmt/tasks/task.py
+++ b/qmt/tasks/task.py
@@ -146,7 +146,8 @@ class Task(object):
             current_options = replace_tag_with_value(current_options, tag, tag_values[tag])
         return current_options
 
-    def _solve_instance(self, input_result_list, current_options):
+    @staticmethod
+    def _solve_instance(input_result_list, current_options):
         """
         Does the actual computation of this.
 
@@ -163,7 +164,8 @@ class Task(object):
         """
         raise NotImplementedError("Task is missing the _solve_instance method!")
 
-    def _solve_gathered(self, list_of_input_result_lists, list_of_current_options):
+    @staticmethod
+    def _solve_gathered(list_of_input_result_lists, list_of_current_options, result_sweep):
         """
         Does the actual computation of a 'gathered' task (e.g. COMSOL meshing).
 
@@ -177,6 +179,7 @@ class Task(object):
         :param list_of_input_result_lists: The list of results produced by dependent tasks, in the order
         that the dependent tasks were given in the call to the Task base class constructor.
         :param list_of_current_options: The list of options of this corresponding to the current sweep iteration.
+        :param result_sweep: Empty ReducedSweepResults object
         """
         raise NotImplementedError("Task is missing the _solve_gathered method!")
 
@@ -208,12 +211,13 @@ class Task(object):
 
                 if not self.gather:
                     # Create a delayed object for this task's computation.
-                    output = delayed(self._solve_instance)(input_result_list, current_options,
+                    output = delayed(self.__class__._solve_instance)(input_result_list, current_options,
                                                            dask_key_name=self.name + '_' + str(sweep_holder_index))
                     self.delayed_result.add(output, sweep_holder_index)
             if self.gather:
-                self.delayed_result = delayed(self._solve_gathered)(list_of_input_result_lists, list_of_current_options,
-                                                                    dask_key_name=self.name)
+                result_sweep = ReducedSweepResults.create_empty_from_manager_and_tags(self.sweep_manager, self.list_of_tags)
+                self.delayed_result = delayed(self.__class__._solve_gathered)(list_of_input_result_lists, list_of_current_options,
+                                                                    result_sweep, dask_key_name=self.name)
 
     def visualize_entire_sweep(self, filename=None):
         """
@@ -285,8 +289,8 @@ class Task(object):
 
         if self.gather:
             self.sweep_manager = SweepManager.create_empty_sweep(dask_client=None)
-            self.daskless_result = self._solve_gathered([input_result_list], [self.options]).only()
+            self.daskless_result = self.__class__._solve_gathered([input_result_list], [self.options]).only()
         else:
-            self.daskless_result = self._solve_instance(input_result_list, self.options)
+            self.daskless_result = self.__class__._solve_instance(input_result_list, self.options)
 
         return self.daskless_result


### PR DESCRIPTION
Each Task has a _solve_instance method, which is pickled and passed between nodes by dask distributed. If this method is not static, the entire Task class gets pickled and passed between nodes, which leads to inefficiencies and unstable behavior.

In this PR, _solve_instance is made into a static method. This means that the _solve_instance method for each subTask class cannot take "self" as an argument.

Additionally the COMSOL mesh Task's "_solve_gather" method is also static, and is handed in an empty ReducedSweepResults object, instead of creating one inside the _solve_gather function.

Let me know if there are any issues with this!