### PR TITLE
Fix py3 test pipeline: --noconftest prohibits pytest from finding fixtures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ steps:
 - script: |
     docker build -t qmt_test:latest -f Dockerfile .
     docker run qmt_test /bin/bash -c "/usr/local/envs/py27/bin/pytest --verbose --capture=no /app/qmt/tests/py2.7 --junit-xml=/app/tests2.7.xml > /dev/null ; cat /app/tests2.7.xml" > TEST-2.7.xml
-    docker run qmt_test /bin/bash -c "/usr/local/envs/py36/bin/pytest --verbose --capture=no --noconftest /app/qmt/tests/py3 --junit-xml=tests3.xml > /dev/null ; cat /app/tests3.xml" > TEST-3.xml
+    docker run qmt_test /bin/bash -c "/usr/local/envs/py36/bin/pytest --verbose --capture=no /app/qmt/tests/py3 --junit-xml=tests3.xml > /dev/null ; cat /app/tests3.xml" > TEST-3.xml
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: 'TEST-*.xml'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def fix_FCDoc():
 def fix_host_settings(fix_testDir):
     '''Host specific settings.'''
     schema = {
-        'py2env': None
+        'py2env': '/usr/local/envs/py27/bin/python'
     }
 
     import yaml


### PR DESCRIPTION
Andrey, do you remember why you included the --noconftest? It does exactly as advertised and leads to failing integration tests because pytest can't find the fixtures we define in conftest.py.