### PR TITLE
Add serial FreeCAD file passing to 3d geo build

### DIFF
--- a/qmt/data/__init__.py
+++ b/qmt/data/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from .data_utils import load_serial, store_serial, write_deserialised, serialised_file, \
+from .data_utils import load_serial, store_serial, write_deserialised, serialize_file, \
     reduce_data, \
     retrieve_data, stream_data_to_file
 from .geometry import Geo2DData, Geo3DData, Part3DData

--- a/qmt/data/data_utils.py
+++ b/qmt/data/data_utils.py
@@ -37,7 +37,7 @@ def store_serial(obj, save_fct, ext_format, scratch_dir=None):
         scratch_dir = os.curdir
     tmp_path = os.path.join(scratch_dir, uuid.uuid4().hex + '.' + ext_format)
     save_fct(obj, tmp_path)
-    serial_data = serialised_file(tmp_path)
+    serial_data = serialize_file(tmp_path)
     os.remove(tmp_path)
     return serial_data
 

--- a/qmt/data/data_utils.py
+++ b/qmt/data/data_utils.py
@@ -12,7 +12,7 @@ import dask
 import dask.delayed
 
 
-def serialised_file(path):
+def serialize_file(path):
     '''Return a serialised blob of the contents of a given file path.'''
     with open(path, 'rb') as f:
         serial_data = codecs.encode(f.read(), 'base64').decode()

--- a/qmt/tasks/geometry.py
+++ b/qmt/tasks/geometry.py
@@ -65,6 +65,8 @@ def build_3d_geometry(pyenv, input_parts, input_file = None,
         serial_fcdoc = serialize_file(input_file)
     else:
         serial_fcdoc = serialized_input_file
+    if params is None:
+        params = {}
     options_dict = {}
     options_dict['serial_fcdoc'] = serial_fcdoc
     options_dict['input_parts'] = input_parts

--- a/qmt/tasks/geometry.py
+++ b/qmt/tasks/geometry.py
@@ -5,7 +5,7 @@
 
 from shapely.geometry import Polygon, LineString
 
-from qmt.data import Geo2DData, Geo3DData, serialised_file
+from qmt.data import Geo2DData, Geo3DData, serialize_file
 
 
 def build_2d_geometry(parts, edges, lunit='nm', build_order=None):
@@ -42,16 +42,29 @@ def build_2d_geometry(parts, edges, lunit='nm', build_order=None):
     return geo_2d
 
 
-def build_3d_geometry(pyenv, input_file, input_parts, params):
+def build_3d_geometry(pyenv, input_parts, input_file = None,
+                      serialized_input_file = None,params=None):
     """
     Build a geometry in 3D.
     :param str pyenv: path or callable name of the Python 2 executable.
-    :param str input_file: path to FreeCAD template file.
     :param list input_parts: ordered list of input parts, leftmost items get built first
+    :param str input_file: path to FreeCAD template file. Either this or serialized_input_file
+    must be set (but not both).
+    :param bytes input_file: FreeCAD template file that has been serialized using
+    qmt.data.serialize_file. This is useful for passing a file into a docker container or other
+    environment that doesn't have access to a shared drive. Either this or serialized_input_file
+    must be set (but not both).
     :param dict params: dictionary of parameters to use in the freeCAD
-    :return:
+    :return Geo3DData:
     """
-    serial_fcdoc = serialised_file(input_file)
+    if input_file is None and serialized_input_file is None:
+        raise ValueError("One of input_file or serialized_input_file must be non-none.")
+    elif input_file is not None and serialized_input_file is not None:
+        raise ValueError("Both input_file and serialized_input_file were non-none.")
+    elif input_file is not None:
+        serial_fcdoc = serialize_file(input_file)
+    else:
+        serial_fcdoc = serialized_input_file
     options_dict = {}
     options_dict['serial_fcdoc'] = serial_fcdoc
     options_dict['input_parts'] = input_parts

--- a/qmt/tasks/geometry.py
+++ b/qmt/tasks/geometry.py
@@ -50,7 +50,7 @@ def build_3d_geometry(pyenv, input_parts, input_file = None,
     :param list input_parts: ordered list of input parts, leftmost items get built first
     :param str input_file: path to FreeCAD template file. Either this or serialized_input_file
     must be set (but not both).
-    :param bytes input_file: FreeCAD template file that has been serialized using
+    :param bytes serialized_input_file: FreeCAD template file that has been serialized using
     qmt.data.serialize_file. This is useful for passing a file into a docker container or other
     environment that doesn't have access to a shared drive. Either this or serialized_input_file
     must be set (but not both).

--- a/tests/py3/test_geo_task.py
+++ b/tests/py3/test_geo_task.py
@@ -38,7 +38,8 @@ def test_geo_task(fix_py2env, fix_testDir):
     build_order = [block1, block2, sag, wire, shell, block3, substrate, wrap, wrap2]
     results = []
     for d1 in np.linspace(2., 7., 3):
-        built_geo = build_3d_geometry(fix_py2env, input_file_path, build_order, {'d1': d1})
+        built_geo = build_3d_geometry(fix_py2env,input_parts=build_order,input_file=input_file_path,
+                                      params={'d1': d1})
         results += [built_geo]
 
     # Investigate results


### PR DESCRIPTION
This update also changes the name of the serialization function. We add in the option to pass it directly to the build_3d_geometry so that Docker environments don’t need access to a shared drive. We also left the ability to automatically generate it, and added some sanity checks to avoid errors.