### PR TITLE
Make cross sections

### DIFF
--- a/qmt/data/geometry.py
+++ b/qmt/data/geometry.py
@@ -202,14 +202,15 @@ class Geo3DData(object):
             else:
                 pass
 
-    def add_xsec(self, xsec_name, axis=(1., 0.,0.), distance=0.):
+    def add_xsec(self, xsec_name, polygons, axis=(1., 0.,0.), distance=0.):
         """
         Make a cross-section of the geometry perpendicular to the axis at a given distance from the origin.
         :param str xsec_name: a strong giving the name for the cross section.
+        :param dict polygons: dict conrresponding to the cross-section polygons.
         :param tuple axis: Tuple defining the axis that defines the normal of the cross section.
         :param float distance: Distance along the axis used to set the cross section.
         """
-        self.xsecs[xsec_name] = {'axis':axis,'distance':distance}
+        self.xsecs[xsec_name] = {'axis':axis,'distance':distance,'polygons':polygons}
 
     def set_data(self, data_name, data, scratch_dir=None):
         """

--- a/qmt/data/geometry.py
+++ b/qmt/data/geometry.py
@@ -151,6 +151,7 @@ class Geo3DData(object):
     def __init__(self):
         self.build_order = []
         self.parts = {}  # dict of parts in this geometry
+        self.xsecs = {} # dict of cross-sections in this geometry
         self.serial_fcdoc = None  # serialized FreeCAD document for this geometry
         self.mesh_verts = None  # numpy array corresponding to the mesh vertices
         self.mesh_tets = None  # numpy array; each row contains the vertex indices in one tet
@@ -200,6 +201,15 @@ class Geo3DData(object):
                     "Attempted to remove the part " + part_name + ", which doesn't exist.")
             else:
                 pass
+
+    def add_xsec(self, xsec_name, axis=(1., 0.,0.), distance=0.):
+        """
+        Make a cross-section of the geometry perpendicular to the axis at a given distance from the origin.
+        :param str xsec_name: a strong giving the name for the cross section.
+        :param tuple axis: Tuple defining the axis that defines the normal of the cross section.
+        :param float distance: Distance along the axis used to set the cross section.
+        """
+        self.xsecs[xsec_name] = {'axis':axis,'distance':distance}
 
     def set_data(self, data_name, data, scratch_dir=None):
         """

--- a/qmt/geometry/freecad/objectConstruction.py
+++ b/qmt/geometry/freecad/objectConstruction.py
@@ -857,33 +857,3 @@ def buildCrossSection(sliceInfo, passModel=None):
             sliceParts[name] = slicePart
 
     return sliceParts
-
-
-def build2DGeo(passModel=None):
-    """Construct the 2D geometry entities defined in the json file."""
-    # TODO: THIS FUNCTION NEEDS TO BE UPDATED AFTER modelRevision
-    # RESTRUCTURING!
-    myModel = getModel() if passModel is None else passModel
-    twoDObjs = {}
-    doc = FreeCAD.ActiveDocument
-    for fcName in myModel.modelDict['freeCADInfo']:
-        keys = myModel.modelDict['freeCADInfo'][fcName].keys()
-        if '2DObject' in keys:
-            objType = '2DObject'
-            objControlDict = myModel.modelDict['freeCADInfo'][fcName][objType]
-            returnDict = {}
-            returnDict.update(objControlDict['physicsProps'])
-            returnDict['type'] = objControlDict['type']
-            if objControlDict['type'] == 'boundary':
-                points = [tuple(v.Point)
-                          for v in doc.getObject(fcName).Shape.Vertexes]
-                twoDObjs[fcName] = (points, returnDict)
-            else:
-                lineSegments, cycles = findEdgeCycles(doc.getObject(fcName))
-                for i, cycle in enumerate(cycles):
-                    points = [tuple(lineSegments[idx, 0]) for idx in cycle]
-                    name = fcName
-                    if len(cycles) > 1:
-                        name = '{}_{}'.format(name, i)
-                    twoDObjs[name] = (points, returnDict)
-    return twoDObjs

--- a/qmt/tasks/geometry.py
+++ b/qmt/tasks/geometry.py
@@ -44,7 +44,7 @@ def build_2d_geometry(parts, edges, lunit='nm', build_order=None):
     return geo_2d
 
 
-def build_3d_geometry(pyenv, input_parts, input_file=None,
+def build_3d_geometry(pyenv, input_parts, input_file=None, xsec_dict=None,
                       serialized_input_file=None, params=None):
     """
     Build a geometry in 3D.
@@ -53,6 +53,10 @@ def build_3d_geometry(pyenv, input_parts, input_file=None,
     :param list input_parts: Ordered list of input parts, leftmost items get built first
     :param str input_file: Path to FreeCAD template file. Either this or serialized_input_file
         must be set (but not both).
+    :param dict xsec_dict: Dictionary of cross-section specifications. It should be of the
+        form {'xsec_name':{'axis':(1,0,0),'distance':0.}}, where the axis parameter is a tuple
+        defining the axis that defines the normal of the cross section, and distance is
+        the length along the axis used to set the cross section.
     :param bytes serialized_input_file: FreeCAD template file that has been serialized using
         qmt.data.serialize_file. This is useful for passing a
         file into a docker container or other environment that
@@ -71,10 +75,13 @@ def build_3d_geometry(pyenv, input_parts, input_file=None,
         serial_fcdoc = serialized_input_file
     if params is None:
         params = {}
+    if xsec_dict is None:
+        xsec_dict = {}
     options_dict = {}
     options_dict['serial_fcdoc'] = serial_fcdoc
     options_dict['input_parts'] = input_parts
     options_dict['params'] = params
+    options_dict['xsec_dict'] = xsec_dict
     # Convert NumPy3 floats to something that Python2 can unpickle
     if 'params' in options_dict:
         options_dict['params'] = {

--- a/tests/py2.7/test_freecad_objectConstruction.py
+++ b/tests/py2.7/test_freecad_objectConstruction.py
@@ -13,7 +13,8 @@ def test_build(fix_exampleDir, fix_FCDoc):
     opts = {
         'pyenv': 'python2',
         'file_path': os.path.join(fix_exampleDir, 'geometry_sweep_showcase.fcstd'),
-        'input_parts': [myPart]
+        'input_parts': [myPart],
+        'xsec_dict':{}
         }
     fix_FCDoc.load(opts['file_path'])
     build(opts)


### PR DESCRIPTION
This PR restores the ability to make cross sections from a 3D geometry. To avoid excessive calls to the wrapper, we specify these ahead of time at the time the geometry task is run. Note that the polygons returned don't know on their own how to define what is "inside" or "outside" of a domain. However, all of the relevant vertices should be there.