### PR TITLE
Add shortcut for specifying fc_names

### DIFF
--- a/qmt/data/geometry.py
+++ b/qmt/data/geometry.py
@@ -281,7 +281,8 @@ class Part3DData(object):
     Create a 3D geometric part.
 
     :param str label: The descriptive name of this new part.
-    :param str fc_name: The name of the 2D/3D freeCAD object that this is built from.
+    :param str fc_name: The name of the 2D/3D freeCAD object that this is built from. Note that if the label used for
+        the 3D part is the same as the freeCAD label, and that label is unique, None may be used here as a shortcut.
     :param str directive: The freeCAD directive is used to construct this part.
         Valid options for this are:
 

--- a/qmt/geometry/freecad/objectConstruction.py
+++ b/qmt/geometry/freecad/objectConstruction.py
@@ -82,7 +82,19 @@ def build(opts):
     geo = Geo3DData()
 
     # Schedule for deletion all objects not explicitly selected by the user
-    input_parts_names = [part.fc_name for part in opts['input_parts']]
+    input_parts_names = []
+    for part in opts['input_parts']:
+        if part.fc_name is None:
+            obj_list = doc.getObjectsByLabel(part.label)
+            assert len(obj_list) == 1
+            fc_name = obj_list[0].Name
+            part.fc_name = fc_name
+        else:
+            fc_name = part.fc_name
+        input_parts_names += [part]
+
+    # input_parts_names = [part.fc_name for part in opts['input_parts']]
+
     blacklist = []
     for obj in doc.Objects:
         if (obj.Name not in input_parts_names) and (obj.TypeId != 'Spreadsheet::Sheet'):


### PR DESCRIPTION
This allows one to specify "none" for the fc_name in a part, as long as the label of the part corresponds to the FC label, and that label is unique. The previous behavior works as it did before, so this is just optional convenience.