### PR TITLE
Add bokeh to the 3.6 environment

### DIFF
--- a/deployment/environment_36.yml
+++ b/deployment/environment_36.yml
@@ -28,3 +28,4 @@ dependencies:
     - dask-jobqueue==0.4.*
     - jupyter==1.0.*
     - adaptive==0.6.*
+    - bokeh==1.0.*


### PR DESCRIPTION
Otherwise, dask schedulers won't start with the bokeh dashboard.