### PR TITLE
Move fenics back to conda

### DIFF
--- a/deployment/environment_36.yml
+++ b/deployment/environment_36.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - numpy=1.15.*
+  - numpy=1.13.*
   - scipy=1.1.*
   - sympy=1.0
   - sphinx=1.8.*
@@ -13,6 +13,7 @@ dependencies:
   - kwant=1.3.*
   - hpc05=v1.30
   - libgfortran-ng=7.2.*
+  - fenics==2017.2.*
   - pip:
     - numpy-stl==2.8.*
     - matplotlib==3.0.*
@@ -23,7 +24,6 @@ dependencies:
     - future==0.17.*
     - holoviews==1.10.*
     - tqdm==4.28.*
-    - fenics==2017.2.*
     - dask==1.0.*
     - dask-jobqueue==0.4.*
     - jupyter==1.0.*


### PR DESCRIPTION
Also changed numpy to 1.13 for compatibility with fenics 2017.2. Using fenics in pip made it not able to import for some reason.