### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/examples/deprecated/tasks_simple.py
+++ b/examples/deprecated/tasks_simple.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 from qmt.basic_tasks import GeometryTask
 from qmt.ms_tasks import PoissonTask
 
@@ -12,4 +13,4 @@ poisson_dict = {'part1':{'voltage':2.},'part2':{'voltage': 1.}}
 poisson_task = PoissonTask(geo_task,options=poisson_dict)
 
 poisson_task.run()
-print poisson_task.result
+print(poisson_task.result)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.