### PR TITLE
Attempt to fix the path in dask test

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -101,9 +101,9 @@ def test_docker_sweep(fix_task_env):
 
     # First, set up dask cluster, which for now is just one scheduler and one worker
     # TODO: Make this run in series of docker containers (e.g. with docker-compose)
-    scheduler_command = ['/usr/local/envs/py36/bin/dask-scheduler',
+    scheduler_command = ['dask-scheduler',
                          '--port', '8781', '--no-bokeh']
-    worker_command = ['/usr/local/envs/py36/bin/dask-worker',
+    worker_command = ['dask-worker',
                       '--nthreads', '1',
                       '--nprocs', '1',
                       '--no-bokeh',


### PR DESCRIPTION
This previously referenced global paths, which might be the wrong version of dask-scheduler and dask-worker.