### PR TITLE
Fix property map bug

### DIFF
--- a/qmt/geometry/property_map.py
+++ b/qmt/geometry/property_map.py
@@ -33,9 +33,12 @@ class PropertyMap(object):
 
         unique_parts = set(np.asanyarray(parts).flat)
         unique_props = [self.propMap(p) for p in unique_parts]
-        obj_type = type(unique_props[0])
-        if obj_type is str:
+        obj_types = [type(p) for p in unique_props]
+        if obj_types[0] is str:
+            assert all(t is str for t in obj_types)
             obj_type = object
+        else:
+            obj_type = np.result_type(*obj_types)
         result = np.empty(np.shape(parts), dtype=obj_type)
         for part, prop in zip(unique_parts, unique_props):
             result[parts == part] = prop

--- a/qmt/materials.json
+++ b/qmt/materials.json
@@ -1,198 +1,198 @@
 {
-  "Al": {
-    "electronMass": 1.0,
-    "fermiEnergy": 11700.0,
-    "relativePermittivity": 1,
-    "type": "metal",
-    "workFunction": 4280.0
-  },
-  "Al2O3": {
-    "electronMass": 1.0,
-    "relativePermittivity": 9.0,
-    "type": "dielectric"
-  },
-  "AlAs": {
-    "directBandGap": 3099,
-    "electronAffinity": 2970.0,
-    "electronMass": 0.15,
-    "interbandMatrixElement": 21100.0,
-    "luttingerGamma1": 3.76,
-    "luttingerGamma2": 0.82,
-    "luttingerGamma3": 1.42,
-    "relativePermittivity": 10.06,
-    "spinOrbitSplitting": 280.0,
-    "type": "semi",
-    "valenceBandOffset": -1330.0
-  },
-  "AlSb": {
-    "directBandGap": 2386.0,
-    "electronMass": 0.14,
-    "interbandMatrixElement": 18700.0,
-    "luttingerGamma1": 5.18,
-    "luttingerGamma2": 1.19,
-    "luttingerGamma3": 1.97,
-    "relativePermittivity": 11.0,
-    "spinOrbitSplitting": 676.0,
-    "type": "semi",
-    "valenceBandOffset": -410.0
-  },
-  "Au": {
-    "electronMass": 1.0,
-    "fermiEnergy": 5530.0,
-    "relativePermittivity": 1,
-    "type": "metal",
-    "workFunction": 5285.0
-  },
-  "GaAs": {
-    "directBandGap": 1519.0,
-    "electronAffinity": 4070.0,
-    "electronMass": 0.067,
-    "interbandMatrixElement": 28800.0,
-    "luttingerGamma1": 6.98,
-    "luttingerGamma2": 2.06,
-    "luttingerGamma3": 2.93,
-    "relativePermittivity": 13.1,
-    "spinOrbitSplitting": 341.0,
-    "type": "semi",
-    "valenceBandOffset": -800.0
-  },
-  "GaSb": {
-    "directBandGap": 812.0,
-    "electronAffinity": 4060.0,
-    "electronMass": 0.039,
-    "interbandMatrixElement": 27000.0,
-    "luttingerGamma1": 13.4,
-    "luttingerGamma2": 4.7,
-    "luttingerGamma3": 6.0,
-    "relativePermittivity": 15.7,
-    "spinOrbitSplitting": 760.0,
-    "type": "semi",
-    "valenceBandOffset": -30.0
-  },
-  "HfO2": {
-    "electronMass": 1.0,
-    "relativePermittivity": 25.0,
-    "type": "dielectric"
-  },
-  "InAs": {
-    "chargeNeutralityLevel": 577.0,
-    "directBandGap": 417.0,
-    "electronAffinity": 4900.0,
-    "electronMass": 0.026,
-    "interbandMatrixElement": 21500.0,
-    "luttingerGamma1": 20.0,
-    "luttingerGamma2": 8.5,
-    "luttingerGamma3": 9.2,
-    "relativePermittivity": 15.15,
-    "spinOrbitSplitting": 390.0,
-    "surfaceChargeDensity": 3000000000000.0,
-    "type": "semi",
-    "valenceBandOffset": -590.0
-  },
-  "InP": {
-    "directBandGap": 1423.6,
-    "electronAffinity": 4380.0,
-    "electronMass": 0.0795,
-    "interbandMatrixElement": 20700.0,
-    "luttingerGamma1": 5.08,
-    "luttingerGamma2": 1.6,
-    "luttingerGamma3": 2.1,
-    "relativePermittivity": 12.5,
-    "spinOrbitSplitting": 108.0,
-    "type": "semi",
-    "valenceBandOffset": -940.0
-  },
-  "InSb": {
-    "chargeNeutralityLevel": 117.5,
-    "directBandGap": 235.0,
-    "electronAffinity": 4590.0,
-    "electronMass": 0.0135,
-    "interbandMatrixElement": 23300.0,
-    "luttingerGamma1": 34.8,
-    "luttingerGamma2": 15.5,
-    "luttingerGamma3": 16.5,
-    "relativePermittivity": 16.8,
-    "spinOrbitSplitting": 810.0,
-    "surfaceChargeDensity": 3000000000000.0,
-    "type": "semi",
-    "valenceBandOffset": 0.0
-  },
-  "NbTiN": {
-    "electronMass": 1.0,
-    "fermiEnergy": 5530.0,
-    "relativePermittivity": 1,
-    "type": "metal",
-    "workFunction": 4280.0
-  },
-  "Si": {
-    "directBandGap": 3480.0,
-    "electronAffinity": 4050.0,
-    "electronMass": 1.1079316513508928,
-    "luttingerGamma1": 4.28,
-    "luttingerGamma2": 0.339,
-    "luttingerGamma3": 1.446,
-    "relativePermittivity": 11.7,
-    "spinOrbitSplitting": 44.0,
-    "type": "semi"
-  },
-  "Si3N4": {
-    "electronMass": 1.0,
-    "relativePermittivity": 7.0,
-    "type": "dielectric"
-  },
-  "SiO2": {
-    "electronMass": 1.0,
-    "relativePermittivity": 3.9,
-    "type": "dielectric"
-  },
-  "ZrO2": {
-    "electronMass": 1.0,
-    "relativePermittivity": 25.0,
-    "type": "dielectric"
-  },
-  "__bowing_parameters": {
-    "('AlAs', 'GaAs')": {
-      "electronMass": 0.0,
-      "type": "semi"
+    "Al": {
+        "electronMass": 1.0,
+        "fermiEnergy": 11700.0,
+        "relativePermittivity": 1.0,
+        "type": "metal",
+        "workFunction": 4280.0
     },
-    "('AlAs', 'InAs')": {
-      "directBandGap": 700.0,
-      "electronMass": 0.049,
-      "spinOrbitSplitting": 150.0,
-      "type": "semi",
-      "valenceBandOffset": -640.0
+    "Al2O3": {
+        "electronMass": 1.0,
+        "relativePermittivity": 9.0,
+        "type": "dielectric"
     },
-    "('GaAs', 'InAs')": {
-      "directBandGap": 477.0,
-      "electronMass": 0.0091,
-      "interbandMatrixElement": -1480.0,
-      "spinOrbitSplitting": 150.0,
-      "type": "semi",
-      "valenceBandOffset": -380.0
+    "AlAs": {
+        "directBandGap": 3099.0,
+        "electronAffinity": 2970.0,
+        "electronMass": 0.15,
+        "interbandMatrixElement": 21100.0,
+        "luttingerGamma1": 3.76,
+        "luttingerGamma2": 0.82,
+        "luttingerGamma3": 1.42,
+        "relativePermittivity": 10.06,
+        "spinOrbitSplitting": 280.0,
+        "type": "semi",
+        "valenceBandOffset": -1330.0
     },
-    "('GaSb', 'InSb')": {
-      "directBandGap": 425.0,
-      "electronMass": 0.0092,
-      "spinOrbitSplitting": 100.0,
-      "type": "semi"
+    "AlSb": {
+        "directBandGap": 2386.0,
+        "electronMass": 0.14,
+        "interbandMatrixElement": 18700.0,
+        "luttingerGamma1": 5.18,
+        "luttingerGamma2": 1.19,
+        "luttingerGamma3": 1.97,
+        "relativePermittivity": 11.0,
+        "spinOrbitSplitting": 676.0,
+        "type": "semi",
+        "valenceBandOffset": -410.0
     },
-    "('InAs', 'InSb')": {
-      "directBandGap": 670.0,
-      "electronMass": 0.035,
-      "spinOrbitSplitting": 1200.0,
-      "type": "semi"
+    "Au": {
+        "electronMass": 1.0,
+        "fermiEnergy": 5530.0,
+        "relativePermittivity": 1.0,
+        "type": "metal",
+        "workFunction": 5285.0
+    },
+    "GaAs": {
+        "directBandGap": 1519.0,
+        "electronAffinity": 4070.0,
+        "electronMass": 0.067,
+        "interbandMatrixElement": 28800.0,
+        "luttingerGamma1": 6.98,
+        "luttingerGamma2": 2.06,
+        "luttingerGamma3": 2.93,
+        "relativePermittivity": 13.1,
+        "spinOrbitSplitting": 341.0,
+        "type": "semi",
+        "valenceBandOffset": -800.0
+    },
+    "GaSb": {
+        "directBandGap": 812.0,
+        "electronAffinity": 4060.0,
+        "electronMass": 0.039,
+        "interbandMatrixElement": 27000.0,
+        "luttingerGamma1": 13.4,
+        "luttingerGamma2": 4.7,
+        "luttingerGamma3": 6.0,
+        "relativePermittivity": 15.7,
+        "spinOrbitSplitting": 760.0,
+        "type": "semi",
+        "valenceBandOffset": -30.0
+    },
+    "HfO2": {
+        "electronMass": 1.0,
+        "relativePermittivity": 25.0,
+        "type": "dielectric"
+    },
+    "InAs": {
+        "chargeNeutralityLevel": 577.0,
+        "directBandGap": 417.0,
+        "electronAffinity": 4900.0,
+        "electronMass": 0.026,
+        "interbandMatrixElement": 21500.0,
+        "luttingerGamma1": 20.0,
+        "luttingerGamma2": 8.5,
+        "luttingerGamma3": 9.2,
+        "relativePermittivity": 15.15,
+        "spinOrbitSplitting": 390.0,
+        "surfaceChargeDensity": 3000000000000.0,
+        "type": "semi",
+        "valenceBandOffset": -590.0
+    },
+    "InP": {
+        "directBandGap": 1423.6,
+        "electronAffinity": 4380.0,
+        "electronMass": 0.0795,
+        "interbandMatrixElement": 20700.0,
+        "luttingerGamma1": 5.08,
+        "luttingerGamma2": 1.6,
+        "luttingerGamma3": 2.1,
+        "relativePermittivity": 12.5,
+        "spinOrbitSplitting": 108.0,
+        "type": "semi",
+        "valenceBandOffset": -940.0
+    },
+    "InSb": {
+        "chargeNeutralityLevel": 117.5,
+        "directBandGap": 235.0,
+        "electronAffinity": 4590.0,
+        "electronMass": 0.0135,
+        "interbandMatrixElement": 23300.0,
+        "luttingerGamma1": 34.8,
+        "luttingerGamma2": 15.5,
+        "luttingerGamma3": 16.5,
+        "relativePermittivity": 16.8,
+        "spinOrbitSplitting": 810.0,
+        "surfaceChargeDensity": 3000000000000.0,
+        "type": "semi",
+        "valenceBandOffset": 0.0
+    },
+    "NbTiN": {
+        "electronMass": 1.0,
+        "fermiEnergy": 5530.0,
+        "relativePermittivity": 1.0,
+        "type": "metal",
+        "workFunction": 4280.0
+    },
+    "Si": {
+        "directBandGap": 3480.0,
+        "electronAffinity": 4050.0,
+        "electronMass": 1.1079316513508928,
+        "luttingerGamma1": 4.28,
+        "luttingerGamma2": 0.339,
+        "luttingerGamma3": 1.446,
+        "relativePermittivity": 11.7,
+        "spinOrbitSplitting": 44.0,
+        "type": "semi"
+    },
+    "Si3N4": {
+        "electronMass": 1.0,
+        "relativePermittivity": 7.0,
+        "type": "dielectric"
+    },
+    "SiO2": {
+        "electronMass": 1.0,
+        "relativePermittivity": 3.9,
+        "type": "dielectric"
+    },
+    "ZrO2": {
+        "electronMass": 1.0,
+        "relativePermittivity": 25.0,
+        "type": "dielectric"
+    },
+    "__bowing_parameters": {
+        "('AlAs', 'GaAs')": {
+            "electronMass": 0.0,
+            "type": "semi"
+        },
+        "('AlAs', 'InAs')": {
+            "directBandGap": 700.0,
+            "electronMass": 0.049,
+            "spinOrbitSplitting": 150.0,
+            "type": "semi",
+            "valenceBandOffset": -640.0
+        },
+        "('GaAs', 'InAs')": {
+            "directBandGap": 477.0,
+            "electronMass": 0.0091,
+            "interbandMatrixElement": -1480.0,
+            "spinOrbitSplitting": 150.0,
+            "type": "semi",
+            "valenceBandOffset": -380.0
+        },
+        "('GaSb', 'InSb')": {
+            "directBandGap": 425.0,
+            "electronMass": 0.0092,
+            "spinOrbitSplitting": 100.0,
+            "type": "semi"
+        },
+        "('InAs', 'InSb')": {
+            "directBandGap": 670.0,
+            "electronMass": 0.035,
+            "spinOrbitSplitting": 1200.0,
+            "type": "semi"
+        }
+    },
+    "air": {
+        "electronMass": 1.0,
+        "relativePermittivity": 1.0,
+        "type": "dielectric"
+    },
+    "degenDopedSi": {
+        "electronMass": 1.0,
+        "fermiEnergy": 5530.0,
+        "relativePermittivity": 1.0,
+        "type": "metal",
+        "workFunction": 4050.0
     }
-  },
-  "air": {
-    "electronMass": 1.0,
-    "relativePermittivity": 1,
-    "type": "dielectric"
-  },
-  "degenDopedSi": {
-    "electronMass": 1.0,
-    "fermiEnergy": 5530.0,
-    "relativePermittivity": 1,
-    "type": "metal",
-    "workFunction": 4050.0
-  }
 }

--- a/qmt/materials.py
+++ b/qmt/materials.py
@@ -200,7 +200,7 @@ class Materials(collections.Mapping):
 
         def set_property(key):
             if key in kwargs and kwargs[key] is not None:
-                material[key] = kwargs.pop(key)
+                material[key] = float(kwargs.pop(key))
 
         material['type'] = mat_type
         set_property('relativePermittivity')  # \eps_r

--- a/tests/test_property_map.py
+++ b/tests/test_property_map.py
@@ -36,6 +36,15 @@ def test_property_map():
     assert np.all(prop_map1(-np.ones((2, 3))) == 'no')
 
 
+def test_property_map_nonuniform_types():
+    str_map = DummyPartMap(['part1', 'part2'])
+    props = {'part1': 1, 'part2': 1.5}
+    prop_map = PropertyMap(str_map, lambda p: props[p])
+    assert prop_map((1., 2.)) == 1.5
+    assert np.all(prop_map(np.ones((2, 3))) == 1.5)
+    assert np.all(prop_map(-np.ones((2, 3))) == 1)
+
+
 def test_materials_property_map():
     int_map = DummyPartMap([0, 1])
     str_map = DummyPartMap(['part1', 'part2'])


### PR DESCRIPTION
When properties of different parts had different types (e.g. int vs float) this could lead to randomly occurring truncations.

Also enforce uniform float type for material properties across different materials for consistency.