### PR TITLE
feat(units): adding units, changing tf2d interface

### DIFF
--- a/qmt/data/solvers_2d.py
+++ b/qmt/data/solvers_2d.py
@@ -3,20 +3,21 @@
 
 from collections import namedtuple
 from typing import NamedTuple, Tuple
-from qmt.physics_constants import ArrayQuantity, Quantity
+from sympy.core.mul import Mul
+import numpy as np
 
 Potential2dData = namedtuple('Potential2dData', ['coordinates', 'coordinate_units', 'potential',
                                                  'potential_units'])
 
 
 class ThomasFermi2dData(NamedTuple):
-    coordinates: Tuple[ArrayQuantity, ArrayQuantity]
-    potential: ArrayQuantity
-    density: ArrayQuantity
-    conduction_band: Quantity
-    valence_band: Quantity
-    reference_level: Quantity
-    temperature: Quantity
+    coordinates: Tuple[np.ndarray, np.ndarray]
+    potential: np.ndarray
+    density: np.ndarray
+    conduction_band: Mul
+    valence_band: Mul
+    reference_level: Mul
+    temperature: Mul
 
 
 Bdg2dData = namedtuple('Bdg2dData', ['coordinates',

--- a/qmt/data/solvers_2d.py
+++ b/qmt/data/solvers_2d.py
@@ -14,8 +14,8 @@ class ThomasFermi2dData(NamedTuple):
     coordinates: Tuple[np.ndarray, np.ndarray]
     potential: np.ndarray
     density: np.ndarray
-    conduction_band: Mul
-    valence_band: Mul
+    conduction_band: np.ndarray
+    valence_band: np.ndarray
     reference_level: Mul
     temperature: Mul
 

--- a/qmt/data/solvers_2d.py
+++ b/qmt/data/solvers_2d.py
@@ -35,8 +35,6 @@ Phase2dData = namedtuple('Phase2dData', ['coordinates',
                                          ])
 
 # TODO: this needs to be pruned
-
-
 class SchrodingerPoissonDatas:
     def __init__(self, poisson_obj, density, density_per_subband, density_units, rho, rho_units,
                  psis, energies, potential, potential_units, mesh, mesh_units, bands, temperature,

--- a/qmt/data/solvers_2d.py
+++ b/qmt/data/solvers_2d.py
@@ -2,20 +2,22 @@
 # Licensed under the MIT License.
 
 from collections import namedtuple
+from typing import NamedTuple, Tuple
+from qmt.physics_constants import ArrayQuantity, Quantity
 
 Potential2dData = namedtuple('Potential2dData', ['coordinates', 'coordinate_units', 'potential',
                                                  'potential_units'])
-ThomasFermi2dData = namedtuple('ThomasFermi2dData', ['coordinates',
-                                                     'potential',
-                                                     'density',
-                                                     'conduction_band',
-                                                     'valence_band',
-                                                     'reference_level',
-                                                     'temperature',
-                                                     'coordinate_units',
-                                                     'potential_units',
-                                                     'energy_units'
-                                                     ])
+
+
+class ThomasFermi2dData(NamedTuple):
+    coordinates: Tuple[ArrayQuantity, ArrayQuantity]
+    potential: ArrayQuantity
+    density: ArrayQuantity
+    conduction_band: Quantity
+    valence_band: Quantity
+    reference_level: Quantity
+    temperature: Quantity
+
 
 Bdg2dData = namedtuple('Bdg2dData', ['coordinates',
                                      'energies',
@@ -29,9 +31,11 @@ Bdg2dData = namedtuple('Bdg2dData', ['coordinates',
 Phase2dData = namedtuple('Phase2dData', ['coordinates',
                                          'superconducting_phase',
                                          'coordinate_units',
-                                        ])
+                                         ])
 
 # TODO: this needs to be pruned
+
+
 class SchrodingerPoissonDatas:
     def __init__(self, poisson_obj, density, density_per_subband, density_units, rho, rho_units,
                  psis, energies, potential, potential_units, mesh, mesh_units, bands, temperature,
@@ -73,13 +77,15 @@ class SchrodingerPoissonDatas:
         self.content['poisson'] = self.poisson
         self.content['density'] = self.density
         self.content['density_per_subband'] = self.density_per_subband
-        self.content['density_units'] = self._serialize_unit(self.density_units)
+        self.content['density_units'] = self._serialize_unit(
+            self.density_units)
         self.content['rho'] = self.rho
         self.content['rho_units'] = self._serialize_unit(self.rho_units)
         self.content['psis'] = self.psis
         self.content['energies'] = self.energies
         self.content['potential'] = self.potential
-        self.content['potential_units'] = self._serialize_unit(self.potential_units)
+        self.content['potential_units'] = self._serialize_unit(
+            self.potential_units)
         self.content['mesh'] = self.mesh
         self.content['mesh_units'] = self._serialize_unit(self.mesh_units)
         self.content['bands'] = self.bands
@@ -94,13 +100,15 @@ class SchrodingerPoissonDatas:
         self.poisson = self.content['poisson']
         self.density = self.content['density']
         self.density_per_subband = self.content['density_per_subband']
-        self.denisty_units = self._deserialize_unit(self.content['density_units'])
+        self.denisty_units = self._deserialize_unit(
+            self.content['density_units'])
         self.rho = self.content['rho']
         self.rho_units = self._deserialize_unit(self.content['rho_units'])
         self.psis = self.content['psis']
         self.energies = self.content['energies']
         self.potential = self.content['potential']
-        self.potential_units = self._deserialize_unit(self.content['potential_units'])
+        self.potential_units = self._deserialize_unit(
+            self.content['potential_units'])
         self.mesh = self.content['mesh']
         self.mesh_units = self._deserialize_unit(self.content['mesh_units'])
         self.bands = self.content['bands']

--- a/qmt/physics_constants.py
+++ b/qmt/physics_constants.py
@@ -114,47 +114,4 @@ matrices.tau_zy = kron(matrices.s_z, matrices.s_y)
 matrices.tau_zz = kron(matrices.s_z, matrices.s_z)
 
 
-class ArrayQuantity(np.ndarray):
-    """
-    Extend a numpy array to have units information from sympy
-    From https://docs.scipy.org/doc/numpy/user/basics.subclassing.html#simple-example-adding-an-extra-attribute-to-ndarray
-    """
-    def __new__(cls, input_array, unit=None):
-        # Input array is an already formed ndarray instance
-        # We first cast to be our class type
-        obj = np.asarray(input_array).view(cls)
-        # add the unit to the created instance
-        obj.unit = unit
-        obj.dtype = input_array.dtype
-        # Finally, we must return the newly created object:
-        return obj
-
-    def __array_finalize__(self, obj):
-        # see InfoArray.__array_finalize__ for comments
-        if obj is None:
-            return
-        self.info = getattr(obj, 'info', None)
-
-    def is_dimensionless(self):
-        return self.unit == None
-
-
-class Quantity(float):
-    """
-    A simple subclass of float that includes a unit
-    Note that this is only a wrapper that does not support arithematic operations or comparisons.
-    Those only work with the float values, and does not take the units into account. We might want
-    to switch to pint (https://github.com/hgrecco/pint) if we want to support that
-    """
-    def __new__(cls, value: float, unit=None):
-        return super().__new__(cls, value)
-
-    def __init__(self, value: float, unit=None):
-        self.unit = unit
-
-    def is_dimensionless(self):
-        return self.unit == None
-
-
-__all__ = ["units", "constants", "matrices",
-           "parse_unit", "to_float", "Quantity", "ArrayQuantity"]
+__all__ = ["units", "constants", "matrices", "parse_unit", "to_float"]

--- a/qmt/physics_constants.py
+++ b/qmt/physics_constants.py
@@ -86,6 +86,11 @@ def to_float(expr):
     return float(cancel(expr))
 
 
+def to_float_vec(arr):
+    """Vectorized version of to_float"""
+    return np.vectorize(to_float)(arr)
+
+
 matrices = SimpleNamespace(
     s_0=eye(2),
     s_x=msigma(1),
@@ -114,4 +119,4 @@ matrices.tau_zy = kron(matrices.s_z, matrices.s_y)
 matrices.tau_zz = kron(matrices.s_z, matrices.s_z)
 
 
-__all__ = ["units", "constants", "matrices", "parse_unit", "to_float"]
+__all__ = ["units", "constants", "matrices", "parse_unit", "to_float", "to_float_vec"]


### PR DESCRIPTION
- Adding subclasses to float and numpy array to let them carry unit information. Note that this is intentionally a very thin wrapper and I don't support things like arithmetics/comparisons that also take unit into account. To do that we'll have to use a full units framework (https://github.com/hgrecco/pint looks pretty good), but then we'll be taking on one more dependency and can't use numpy operations that pint doesn't support.
- Making ThomasFermi2dData a typed NamedTuple