### PR TITLE
always close the document

### DIFF
--- a/qmt/tasks/geometry.py
+++ b/qmt/tasks/geometry.py
@@ -92,8 +92,13 @@ def build_3d_geometry(
     data = Geo3DData()
     data.serial_fcdoc = serial_fcdoc
     data.get_data("fcdoc")
+
     from qmt.geometry.freecad.objectConstruction import build
 
-    built = build(options_dict)
+    try:
+        built = build(options_dict)
+    except Exception:
+        FreeCAD.closeDocument("instance")
+        raise
     FreeCAD.closeDocument("instance")
     return built


### PR DESCRIPTION
Right now, when an exception happens in `build`, the internal state isn't reset. Running the same (faulty) code cell again will result in a different error.

This fix ensures the correct cleanup.

We might also introduce our custom `contextmanager` to do this job.