### PR TITLE
add miniver, get __version__ from git tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+qmt/_static_version.py export-subst

--- a/qmt/__init__.py
+++ b/qmt/__init__.py
@@ -1,4 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
+from ._version import __version__
+
+del _version
+
 from .physics_constants import units, constants, parse_unit, to_float
 from .materials import Materials

--- a/qmt/_static_version.py
+++ b/qmt/_static_version.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# This file is part of 'miniver': https://github.com/jbweston/miniver
+#
+# This file will be overwritten by setup.py when a source or binary
+# distribution is made.  The magic value "__use_git__" is interpreted by
+# _version.py.
+
+version = "__use_git__"
+
+# These values are only set if the distribution was created with 'git archive'
+refnames = "$Format:%D$"
+git_hash = "$Format:%h$"

--- a/qmt/_version.py
+++ b/qmt/_version.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# This file is part of 'miniver': https://github.com/jbweston/miniver
+#
+from collections import namedtuple
+import os
+import subprocess
+
+from distutils.command.build_py import build_py as build_py_orig
+from setuptools.command.sdist import sdist as sdist_orig
+
+Version = namedtuple("Version", ("release", "dev", "labels"))
+
+# No public API
+__all__ = []
+
+package_root = os.path.dirname(os.path.realpath(__file__))
+package_name = os.path.basename(package_root)
+distr_root = os.path.dirname(package_root)
+
+STATIC_VERSION_FILE = "_static_version.py"
+
+
+def get_version(version_file=STATIC_VERSION_FILE):
+    version_info = get_static_version_info(version_file)
+    version = version_info["version"]
+    if version == "__use_git__":
+        version = get_version_from_git()
+        if not version:
+            version = get_version_from_git_archive(version_info)
+        if not version:
+            version = Version("unknown", None, None)
+        return pep440_format(version)
+    else:
+        return version
+
+
+def get_static_version_info(version_file=STATIC_VERSION_FILE):
+    version_info = {}
+    with open(os.path.join(package_root, version_file), "rb") as f:
+        exec(f.read(), {}, version_info)
+    return version_info
+
+
+def version_is_from_git(version_file=STATIC_VERSION_FILE):
+    return get_static_version_info(version_file)["version"] == "__use_git__"
+
+
+def pep440_format(version_info):
+    release, dev, labels = version_info
+
+    version_parts = [release]
+    if dev:
+        if release.endswith("-dev") or release.endswith(".dev"):
+            version_parts.append(dev)
+        else:  # prefer PEP440 over strict adhesion to semver
+            version_parts.append(".dev{}".format(dev))
+
+    if labels:
+        version_parts.append("+")
+        version_parts.append(".".join(labels))
+
+    return "".join(version_parts)
+
+
+def get_version_from_git():
+    try:
+        p = subprocess.Popen(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=distr_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError:
+        return
+    if p.wait() != 0:
+        return
+    if not os.path.samefile(p.communicate()[0].decode().rstrip("\n"), distr_root):
+        # The top-level directory of the current Git repository is not the same
+        # as the root directory of the distribution: do not extract the
+        # version from Git.
+        return
+
+    # git describe --first-parent does not take into account tags from branches
+    # that were merged-in. The '--long' flag gets us the 'dev' version and
+    # git hash, '--always' returns the git hash even if there are no tags.
+    for opts in [["--first-parent"], []]:
+        try:
+            p = subprocess.Popen(
+                ["git", "describe", "--long", "--always"] + opts,
+                cwd=distr_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError:
+            return
+        if p.wait() == 0:
+            break
+    else:
+        return
+
+    description = (
+        p.communicate()[0]
+        .decode()
+        .strip("v")  # Tags can have a leading 'v', but the version should not
+        .rstrip("\n")
+        .rsplit("-", 2)  # Split the latest tag, commits since tag, and hash
+    )
+
+    try:
+        release, dev, git = description
+    except ValueError:  # No tags, only the git hash
+        # prepend 'g' to match with format returned by 'git describe'
+        git = "g{}".format(*description)
+        release = "unknown"
+        dev = None
+
+    labels = []
+    if dev == "0":
+        dev = None
+    else:
+        labels.append(git)
+
+    try:
+        p = subprocess.Popen(["git", "diff", "--quiet"], cwd=distr_root)
+    except OSError:
+        labels.append("confused")  # This should never happen.
+    else:
+        if p.wait() == 1:
+            labels.append("dirty")
+
+    return Version(release, dev, labels)
+
+
+# TODO: change this logic when there is a git pretty-format
+#       that gives the same output as 'git describe'.
+#       Currently we can only tell the tag the current commit is
+#       pointing to, or its hash (with no version info)
+#       if it is not tagged.
+def get_version_from_git_archive(version_info):
+    try:
+        refnames = version_info["refnames"]
+        git_hash = version_info["git_hash"]
+    except KeyError:
+        # These fields are not present if we are running from an sdist.
+        # Execution should never reach here, though
+        return None
+
+    if git_hash.startswith("$Format") or refnames.startswith("$Format"):
+        # variables not expanded during 'git archive'
+        return None
+
+    VTAG = "tag: v"
+    refs = set(r.strip() for r in refnames.split(","))
+    version_tags = set(r[len(VTAG) :] for r in refs if r.startswith(VTAG))
+    if version_tags:
+        release, *_ = sorted(version_tags)  # prefer e.g. "2.0" over "2.0rc1"
+        return Version(release, dev=None, labels=None)
+    else:
+        return Version("unknown", dev=None, labels=["g{}".format(git_hash)])
+
+
+__version__ = get_version()
+
+
+# The following section defines a module global 'cmdclass',
+# which can be used from setup.py. The 'package_name' and
+# '__version__' module globals are used (but not modified).
+
+
+def _write_version(fname):
+    # This could be a hard link, so try to delete it first.  Is there any way
+    # to do this atomically together with opening?
+    try:
+        os.remove(fname)
+    except OSError:
+        pass
+    with open(fname, "w") as f:
+        f.write(
+            "# This file has been created by setup.py.\n"
+            "version = '{}'\n".format(__version__)
+        )
+
+
+class _build_py(build_py_orig):
+    def run(self):
+        super().run()
+        _write_version(os.path.join(self.build_lib, package_name, STATIC_VERSION_FILE))
+
+
+class _sdist(sdist_orig):
+    def make_release_tree(self, base_dir, files):
+        super().make_release_tree(base_dir, files)
+        _write_version(os.path.join(base_dir, package_name, STATIC_VERSION_FILE))
+
+
+cmdclass = dict(sdist=_sdist, build_py=_build_py)

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,24 @@
 
 from setuptools import setup
 
+
+# Loads _version.py module without importing the whole package.
+def get_version_and_cmdclass(package_name):
+    import os
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec = spec_from_file_location("version", os.path.join(package_name, "_version.py"))
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.__version__, module.cmdclass
+
+
+version, cmdclass = get_version_and_cmdclass("qmt")
+
 setup(
     name="qmt",
-    version="1.0",
+    version=version,
+    cmdclass=cmdclass,
     description="Qubit Modeling Tools (QMT) for computational modeling of quantum devices",
     url="https://github.com/Microsoft/qmt",
     author="Andrey Antipov, John Gamble, Jan Gukelberger, Donjan Rodic, Kevin van Hoogdalem, Georg Winkler",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,12 @@
 # Licensed under the MIT License.
 
 from setuptools import setup
+import sys
+
+
+if sys.version_info < (3, 6):
+    print("qmt requires Python 3.6 or above.")
+    sys.exit(1)
 
 
 # Loads _version.py module without importing the whole package.
@@ -21,6 +27,7 @@ version, cmdclass = get_version_and_cmdclass("qmt")
 setup(
     name="qmt",
     version=version,
+    python_requires=">=3.6",
     cmdclass=cmdclass,
     description="Qubit Modeling Tools (QMT) for computational modeling of quantum devices",
     url="https://github.com/Microsoft/qmt",


### PR DESCRIPTION
Currently, there is no way of finding out what version people have installed.

This makes sure that `qms.__version__` is always correctly defined, using [semver](https://semver.org/).

We would for example tag `1.1.0` now by doing:
```
git tag v1.1.0 -m "version 1.1.0"
```

It yields version strings like `1.1.0`, `1.1.0+2.g1076c97`, or `0.11+2.g1076c97.dirty`.

Where `1.1.0+2.g1076c97` means, 2 commits after the tag `1.1.0` and on the git hash 1076c97,
`dirty` means that there are unstaged files.
