### PR TITLE
convert reST docstring style to NumPy style

### DIFF
--- a/qmt/data/data_utils.py
+++ b/qmt/data/data_utils.py
@@ -14,24 +14,63 @@ import tempfile
 
 
 def serialize_file(path):
-    """Return a serialised blob of the contents of a given file path."""
+    """Return a serialised blob of the contents of a given file path.
+
+    Parameters
+    ----------
+    path : str
+        Filename.
+
+    Returns
+    -------
+    serial_data
+
+    """
     with open(path, "rb") as f:
         serial_data = codecs.encode(f.read(), "base64").decode()
     return serial_data
 
 
 def write_deserialised(serial_obj, path):
-    """Write a deserialised file from a serialised blob to a given file path."""
+    """Write a deserialised file from a serialised blob to a given file path.
+
+    Parameters
+    ----------
+    serial_obj :
+
+    path : str
+        Filename.
+
+    Returns
+    -------
+    None
+
+    """
     data = codecs.decode(serial_obj.encode(), "base64")
     with open(path, "wb") as f:
         f.write(data)
 
 
 def store_serial(obj, save_fct, ext_format, scratch_dir=None):
-    """
-    Return a serialised representation of
+    """Return a serialised representation of
     `save_fct(obj, scratch_dir/temporary_file.ext_format)`.
     The parameter `ext_format` can be used for format distinction in some `save_fct`.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    save_fct :
+
+    ext_format :
+
+    scratch_dir : str
+        (Default value = None)
+
+    Returns
+    -------
+    serial_data
+
     """
     if not scratch_dir:
         scratch_dir = tempfile.gettempdir()
@@ -43,9 +82,24 @@ def store_serial(obj, save_fct, ext_format, scratch_dir=None):
 
 
 def load_serial(serial_obj, load_fct, ext_format=None, scratch_dir=None):
-    """
-    Return the original object stored with `store_serial`.
-    The `load_fct` must be a correct complement of the previously used `store_fct`.
+    """Return the original object stored with `store_serial`. The `load_fct`
+    must be a correct complement of the previously used `store_fct`.
+
+    Parameters
+    ----------
+    serial_obj :
+
+    load_fct :
+
+    ext_format :
+        (Default value = None)
+    scratch_dir : str
+        (Default value = None)
+
+    Returns
+    -------
+    obj
+
     """
     if not ext_format:
         ext_format = "tmpdata"
@@ -59,18 +113,25 @@ def load_serial(serial_obj, load_fct, ext_format=None, scratch_dir=None):
 
 
 def reduce_data(reduce_function, task, dask_client):
-    """
-    Given a task that has or will be been run, apply a reduce function to all of its outputs in
+    """Given a task that has or will be been run, apply a reduce function to all of its outputs in
     dask. By specifying a custom `reduce_function`, the user is returning exactly what they want from
     a given run.
 
-    :param function reduce_function: A function that takes the output data type of the supplied
-                                     task and returns a dictionary of objects that can be stored in hdf5.
-    :param Task task: The task that we would like to work on. Note that this function doesn't run
-                      the task, but this can be set up either before or after running.
-    :param dask_client: The client we are using for the calculation
-    :return sweep_vals,extracted_data: Returns a list of the sweep tags and a list of the futures
-                                       corresponding to the data objects.
+    Parameters
+    ----------
+    reduce_function : function
+        A function that takes the output data type of the supplied
+        task and returns a dictionary of objects that can be stored in hdf5.
+    task : Task
+        The task that we would like to work on. Note that this function doesn't run
+        the task, but this can be set up either before or after running.
+    dask_client :
+        The client we are using for the calculation
+
+    Returns
+    -------
+    sweep_vals, extracted_data
+
     """
     sweep_holder = task.computed_result  # List of futures that resolve to the data
     sweep_vals = task.computed_result.sweep.sweep_list  # List of the tag values
@@ -87,29 +148,46 @@ def reduce_data(reduce_function, task, dask_client):
 
 
 def retrieve_data(extracted_data, dask_client):
-    """
-    Retrieves all of the data stored in a list of futures.
+    """Retrieves all of the data stored in a list of futures.
 
-    :param extracted_data: List of futures we ant to retrieve.
-    :param dask_client: Dask client we are using for the calculation.
-    :return retrieved_data: The retrieved data in a list.
+    Parameters
+    ----------
+    extracted_data : list
+        List of futures we ant to retrieve.
+    dask_client :
+        Dask client we are using for the calculation.
+
+    Returns
+    -------
+    retrieved_data
+
     """
     retrieved_data = dask_client.gather(extracted_data)
     return retrieved_data
 
 
 def stream_data_to_file(extracted_data, filename, dask_client, sweep_vals=None):
-    """
-    Instead of simply retrieving all the data, we can stream it to a file on disk as the runs
+    """Instead of simply retrieving all the data, we can stream it to a file on disk as the runs
     complete. The data are stored in an hdf5 file with a single level. Data entries are given by
     kesy of the form "index_paramval", where index is the numerical index of the result in the
     extracted_data list and paramval is the descriptive key for the datum of interest.
 
-    :param extracted_data: List of futures we ant to retrieve.
-    :param filename: File name for the local data store.
-    :param dask_client: The client we are using for the calculation
-    :param sweep_vals: Sweep point values to store along with the data. If None, then just uses
-                       an integer list.
+    Parameters
+    ----------
+    extracted_data : list
+        List of futures we ant to retrieve.
+    filename :
+        File name for the local data store.
+    dask_client :
+        The client we are using for the calculation
+    sweep_vals :
+        Sweep point values to store along with the data. If None, then just uses
+        an integer list. (Default value = None)
+
+    Returns
+    -------
+    None
+
     """
     from tqdm import tqdm
 

--- a/qmt/data/solvers_3d.py
+++ b/qmt/data/solvers_3d.py
@@ -11,7 +11,7 @@ except:
 from qmt.data import store_serial, load_serial
 
 
-class Fem3DData(object):
+class Fem3DData:
     def __init__(
         self,
         coordinates=None,
@@ -45,7 +45,7 @@ class Fem3DData(object):
             print("Unknown datatype {data} for get_data function".format(data=data))
 
 
-class SerialFenicsFunctionData(object):
+class SerialFenicsFunctionData:
     def __init__(self, serial_mesh, serial_function):
         self.serial_mesh = serial_mesh
         self.serial_function = serial_function

--- a/qmt/geometry/freecad/auxiliary.py
+++ b/qmt/geometry/freecad/auxiliary.py
@@ -15,21 +15,58 @@ import FreeCAD
 
 
 def delete(obj):
-    """Delete an object by FreeCAD name."""
+    """Delete an object by FreeCAD name.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+
+    Returns
+    -------
+    None
+
+    """
     doc = FreeCAD.ActiveDocument
     doc.removeObject(obj.Name)
     doc.recompute()
 
 
 def _deepRemove_impl(obj):
-    """ Implementation helper for deepRemove."""
+    """Implementation helper for deepRemove.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+
+    Returns
+    -------
+    None
+
+    """
     for child in obj.OutList:
         _deepRemove_impl(child)
     FreeCAD.ActiveDocument.removeObject(obj.Name)
 
 
 def deepRemove(obj=None, name=None, label=None):
-    """ Remove a targeted object and recursively delete all its sub-objects."""
+    """Remove a targeted object and recursively delete all its sub-objects.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object. (Default value = None)
+    name : str
+        (Default value = None)
+    label : str
+        (Default value = None)
+
+    Returns
+    -------
+    None
+
+    """
     doc = FreeCAD.ActiveDocument
     if obj is not None:
         pass
@@ -65,7 +102,20 @@ def silent_stdout():
 
 
 def _remove_from_zip(zipfname, *filenames):  # pragma: no cover
-    """Remove file names from zip archive."""
+    """Remove file names from zip archive.
+
+    Parameters
+    ----------
+    zipfname : str
+        The file name of the zip-file.
+    *filenames : sequence of strings
+
+
+    Returns
+    -------
+    None
+
+    """
     tempdir = tempfile.mkdtemp()
     try:
         tempname = os.path.join(tempdir, "new.zip")
@@ -81,14 +131,40 @@ def _remove_from_zip(zipfname, *filenames):  # pragma: no cover
 
 
 def _replace_in_zip_fstr(zipfname, filename, content):  # pragma: no cover
-    """Replace a file in a zip archive with some content string."""
+    """Replace a file in a zip archive with some content string.
+
+    Parameters
+    ----------
+    zipfname : str
+        The file name of the zip-file.
+    filename : str
+
+    content :
+
+
+    Returns
+    -------
+    None
+
+    """
     _remove_from_zip(zipfname, filename)
     zfile = zipfile.ZipFile(zipfname, mode="a")
     zfile.writestr(filename, content)
 
 
 def make_objects_visible(zipfname):  # pragma: no cover
-    """Make objects visible in a fcstd file with GuiDocument.xml."""
+    """Make objects visible in a fcstd file with GuiDocument.xml.
+
+    Parameters
+    ----------
+    zipfname : str
+        The file name of the zip-file.
+
+    Returns
+    -------
+    None
+
+    """
     zfile = zipfile.ZipFile(zipfname)
     gui_xml = zfile.read("GuiDocument.xml")
     guitree = ElementTree.fromstring(gui_xml)

--- a/qmt/geometry/freecad/fileIO.py
+++ b/qmt/geometry/freecad/fileIO.py
@@ -14,10 +14,19 @@ from .auxiliary import silent_stdout
 
 
 def exportMeshed(obj_list: Sequence, file_name: str):
-    """ Export a STL 3D Mesh file.
+    """Export a STL 3D Mesh file.
 
-    :param list obj_list:       List of objects to export.
-    :param string file_name:    Name of file to create and export into.
+    Parameters
+    ----------
+    obj_list : list
+        List of objects to export.
+    file_name : str
+        Name of file to create and export into.
+
+    Returns
+    -------
+    None
+
     """
     if not isinstance(obj_list, list):
         raise TypeError("obj_list must be a list of objects.")
@@ -43,10 +52,19 @@ def exportMeshed(obj_list: Sequence, file_name: str):
 
 
 def exportCAD(obj_list: Sequence, file_name: str):
-    """ Export a STEP (Standard for the Exchange of Product Data) 3D CAD file.
+    """Export a STEP (Standard for the Exchange of Product Data) 3D CAD file.
 
-    :param list obj_list:       List of objects to export.
-    :param string file_name:    Name of file to create and export into.
+    Parameters
+    ----------
+    obj_list : list
+        List of objects to export.
+    file_name : str
+        Name of file to create and export into.
+
+    Returns
+    -------
+
+
     """
     if not isinstance(obj_list, list):
         raise TypeError("obj_list must be a list of objects.")

--- a/qmt/geometry/freecad/geomUtils.py
+++ b/qmt/geometry/freecad/geomUtils.py
@@ -16,7 +16,24 @@ vec = FreeCAD.Vector
 
 
 def extrude_partwb(sketch, length, reverse=False, name=None):
-    """Extrude via Part workbench."""
+    """Extrude via Part workbench.
+
+    Parameters
+    ----------
+    sketch :
+
+    length :
+
+    reverse :
+        (Default value = False)
+    name : str
+        (Default value = None)
+
+    Returns
+    -------
+    FreeCAD.Part.Feature
+
+    """
     doc = FreeCAD.ActiveDocument
     if name is None:
         f = doc.addObject("Part::Extrusion")
@@ -38,12 +55,42 @@ def extrude_partwb(sketch, length, reverse=False, name=None):
 
 
 def extrude(sketch, length, reverse=False, name=None):
-    """Selector for extrude method."""
+    """Selector for extrude method.
+
+    Parameters
+    ----------
+    sketch :
+
+    length :
+
+    reverse :
+        (Default value = False)
+    name : str
+        (Default value = None)
+
+    Returns
+    -------
+    FreeCAD.Part.Feature
+
+    """
     return extrude_partwb(sketch, length, reverse, name)
 
 
 def copy_move(obj, moveVec=(0.0, 0.0, 0.0), copy=True):
     """Create a duplciate of the object using a draft move operation.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    moveVec :
+        (Default value = (0.0, 0.0, 0.0))
+    copy :
+        (Default value = True)
+
+    Returns
+    -------
+    f
     """
     f = Draft.move([obj], vec(moveVec[0], moveVec[1], moveVec[2]), copy=copy)
     if f.Shape.Vertexes:
@@ -69,6 +116,20 @@ def makeHexFace(sketch, zBottom, width):
     """Given a sketch for a wire, make the first face. Also need to make sure it
     is placed normal to the initial line segment in the sketch. This will ensure
     that the wire and shell can be constructed with sweep operations.
+
+    Parameters
+    ----------
+    sketch :
+
+    zBottom :
+
+    width :
+
+
+    Returns
+    -------
+    face3
+
     """
     doc = FreeCAD.ActiveDocument
     lineSegments = findSegments(sketch)
@@ -104,6 +165,18 @@ def makeHexFace(sketch, zBottom, width):
 
 def genUnion(objList, consumeInputs=False):
     """Generates a Union non-destructively.
+
+    Parameters
+    ----------
+    objList :
+
+    consumeInputs :
+        (Default value = False)
+
+    Returns
+    -------
+    Object(s).
+
     """
     doc = FreeCAD.ActiveDocument
     if not objList:
@@ -135,6 +208,15 @@ def genUnion(objList, consumeInputs=False):
 
 def getBB(obj):
     """Get the bounding box coords of an object.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    Returns
+    -------
+    Tuple of (xMin, xMax, yMin, yMax, zMin, zMax).
+
     """
     xMin = obj.Shape.BoundBox.XMin
     xMax = obj.Shape.BoundBox.XMax
@@ -147,6 +229,16 @@ def getBB(obj):
 
 def makeBB(BB):
     """Make a bounding box given BB tuple.
+
+    Parameters
+    ----------
+    BB :
+
+
+    Returns
+    -------
+    box
+
     """
     doc = FreeCAD.ActiveDocument
     xMin, xMax, yMin, yMax, zMin, zMax = BB
@@ -164,6 +256,20 @@ def makeBB(BB):
 
 def subtract(obj0, obj1, consumeInputs=False):
     """Subtract two objects, optionally deleting the input objects.
+
+    Parameters
+    ----------
+    obj0 :
+
+    obj1 :
+
+    consumeInputs :
+        (Default value = False)
+
+    Returns
+    -------
+    FreeCAD.App.Document
+
     """
     doc = FreeCAD.ActiveDocument
     tempObj = doc.addObject("Part::Cut")
@@ -181,7 +287,19 @@ def subtract(obj0, obj1, consumeInputs=False):
 
 
 def subtractParts(domainObj, partList):
-    """ Subtract given part objects from a domain.
+    """Subtract given part objects from a domain.
+
+    Parameters
+    ----------
+    domainObj :
+
+    partList :
+
+
+    Returns
+    -------
+    FreeCAD.App.Document
+
     """
     doc = FreeCAD.ActiveDocument
     diffObj = copy_move(domainObj)
@@ -196,6 +314,18 @@ def subtractParts(domainObj, partList):
 
 def intersect(objList, consumeInputs=False):
     """Intersect a list of objects, optionally deleting the input objects.
+
+    Parameters
+    ----------
+    objList :
+
+    consumeInputs :
+        (Default value = False)
+
+    Returns
+    -------
+    FreeCAD.App.Document
+
     """
     doc = FreeCAD.ActiveDocument
     intersectTemp = doc.addObject("Part::MultiCommon")
@@ -212,8 +342,18 @@ def intersect(objList, consumeInputs=False):
 
 
 def checkOverlap(objList):
-    """ Checks if a list of objects, when intersected, contains a finite volume.abs
+    """Checks if a list of objects, when intersected, contains a finite volume.abs
     Returns true if it does, returns false if the intersection is empty.
+
+    Parameters
+    ----------
+    objList :
+
+
+    Returns
+    -------
+    Boolean
+
     """
     intObj = intersect(objList)
     if not intObj.Shape.Vertexes:
@@ -225,7 +365,16 @@ def checkOverlap(objList):
 
 
 def isNonempty(obj):
-    """ Checks if an object is nonempty (returns True) or empty (returns False).
+    """Checks if an object is nonempty (returns True) or empty (returns False).
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    Returns
+    -------
+    Boolean
+
     """
     if not obj.Shape.Vertexes:
         return False
@@ -234,7 +383,23 @@ def isNonempty(obj):
 
 
 def extrudeBetween(sketch, zMin, zMax, name=None):
-    """ Non-destructively extrude a sketch between zMin and zMax.
+    """Non-destructively extrude a sketch between zMin and zMax.
+
+    Parameters
+    ----------
+    sketch :
+
+    zMin : float
+
+    zMax : float
+
+    name : str
+        (Default value = None)
+
+    Returns
+    -------
+    ext
+
     """
     doc = FreeCAD.ActiveDocument
     tempExt = extrude(sketch, zMax - zMin, name=name)
@@ -246,8 +411,22 @@ def extrudeBetween(sketch, zMin, zMax, name=None):
 
 
 def liftObject(obj, d, consumeInputs=False):
-    """ Create a new solid by lifting an object by a distance d along z, filling
+    """Create a new solid by lifting an object by a distance d along z, filling
     in the space swept out.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    d : float
+        Distance.
+    consumeInputs :
+        (Default value = False)
+
+    Returns
+    -------
+    returnObj
+
     """
     objBB = getBB(obj)
     liftedObj = copy_move(obj, moveVec=(0.0, 0.0, d))  # lift up the original sketch
@@ -261,8 +440,21 @@ def liftObject(obj, d, consumeInputs=False):
 
 
 def draftOffset(inputSketch, t):
-    """ Attempt to offset the draft figure by a thickness t. Positive t is an
+    """Attempt to offset the draft figure by a thickness t. Positive t is an
     inflation, while negative t is a deflation.
+
+    Parameters
+    ----------
+    inputSketch :
+
+    t : float
+        Thickness.
+
+
+    Returns
+    -------
+    returnSketch
+
     """
     # ~ from qmt.geometry.freecad.geomUtils import extrude, copy_move, delete
 
@@ -370,8 +562,18 @@ def draftOffset(inputSketch, t):
 
 
 def centerObjects(objsList):
-    """ Move all the objects in the list in the x-y plane so that they are
+    """Move all the objects in the list in the x-y plane so that they are
     centered about the origin.
+
+    Parameters
+    ----------
+    objsList :
+
+
+    Returns
+    -------
+    None
+
     """
     if not objsList:
         return
@@ -385,7 +587,24 @@ def centerObjects(objsList):
 
 
 def crossSection(obj, axis=(1.0, 0.0, 0.0), d=1.0, name=None):
-    """Return cross section of object along axis."""
+    """Return cross section of object along axis.
+
+    Parameters
+    ----------
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    axis :
+        (Default value = (1.0, 0.0, 0.0)
+    d : float
+        (Default value = 1.0)
+    name : str
+        (Default value = None)
+
+    Returns
+    -------
+    returnObj
+
+    """
     doc = FreeCAD.ActiveDocument
     if name is None:
         name = obj.Name + "_section"

--- a/qmt/geometry/freecad/objectConstruction.py
+++ b/qmt/geometry/freecad/objectConstruction.py
@@ -83,8 +83,17 @@ class DummyInfo:
 
 def build(opts):
     """Build the 3D geometry in FreeCAD.
-    :param dict opts:   Options dict in the QMT Geometry3D.__init__ input format.
-    :return geo:        Geo3DData object with the built objects.
+
+    Parameters
+    ----------
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    Returns
+    -------
+    Geo3DData object.
+
     """
     doc = FreeCAD.ActiveDocument
     geo = Geo3DData()
@@ -204,7 +213,18 @@ def build(opts):
 
 
 def build_pass(part):
-    """Pass a part unchanged."""
+    """Pass a part unchanged.
+
+    Parameters
+    ----------
+    part :
+
+
+    Returns
+    -------
+
+
+    """
     assert part.directive == "3d_shape"
     existing_part = FreeCAD.ActiveDocument.getObject(part.fc_name)
     assert existing_part is not None
@@ -212,7 +232,18 @@ def build_pass(part):
 
 
 def build_extrude(part):
-    """Build an extrude part."""
+    """Build an extrude part.
+
+    Parameters
+    ----------
+    part :
+
+
+    Returns
+    -------
+
+
+    """
     assert part.directive == "extrude"
     z0 = part.z0
     deltaz = part.thickness
@@ -228,7 +259,20 @@ def build_extrude(part):
 
 
 def build_sag(part, offset=0.0):
-    """Build a SAG part."""
+    """Build a SAG part.
+
+    Parameters
+    ----------
+    part :
+
+    offset :
+        (Default value = 0.0)
+
+    Returns
+    -------
+
+
+    """
     assert part.directive == "SAG"
     zBot = part.z0
     zMid = part.z_middle
@@ -244,7 +288,20 @@ def build_sag(part, offset=0.0):
 
 
 def build_wire(part, offset=0.0):
-    """Build a wire part."""
+    """Build a wire part.
+
+    Parameters
+    ----------
+    part :
+
+    offset :
+        (Default value = 0.0)
+
+    Returns
+    -------
+
+
+    """
     assert part.directive == "wire"
     doc = FreeCAD.ActiveDocument
     zBottom = part.z0
@@ -256,7 +313,20 @@ def build_wire(part, offset=0.0):
 
 
 def build_wire_shell(part, offset=0.0):
-    """Build a wire shell part."""
+    """Build a wire shell part.
+
+    Parameters
+    ----------
+    part :
+
+    offset :
+        (Default value = 0.0)
+
+    Returns
+    -------
+
+
+    """
     assert part.directive == "wire_shell"
     doc = FreeCAD.ActiveDocument
     zBottom = part.target_wire.z0
@@ -289,7 +359,23 @@ def build_wire_shell(part, offset=0.0):
 
 
 def build_lithography(part, opts, info_holder):
-    """Build a lithography part."""
+    """Build a lithography part.
+
+    Parameters
+    ----------
+    part :
+
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    info_holder :
+
+
+    Returns
+    -------
+
+
+    """
     assert part.directive == "lithography"
     if not info_holder.litho_setup_done:
         initialize_lithography(info_holder, opts, fillShells=True)
@@ -316,6 +402,24 @@ def buildWire(sketch, zBottom, width, faceOverride=None, offset=0.0):
     """Given a line segment, build a nanowire of given cross-sectional width
     with a bottom location at zBottom. Offset produces an offset with a specified
     offset.
+
+    Parameters
+    ----------
+    sketch :
+
+    zBottom :
+
+    width :
+
+    faceOverride :
+        (Default value = None)
+    offset :
+        (Default value = 0.0)
+
+    Returns
+    -------
+
+
     """
     doc = FreeCAD.ActiveDocument
     if faceOverride is None:
@@ -344,6 +448,30 @@ def buildAlShell(
     for simplicity we keep this a thin shell that lies cleanly on top of the
     bigger wire offset. There's no need to include the bottom portion since that's
     already taken up by the wire.
+
+    Parameters
+    ----------
+    sketch :
+
+    zBottom :
+
+    width :
+
+    verts :
+
+    thickness :
+
+    depoZone :
+        (Default value = None)
+    etchZone :
+        (Default value = None)
+    offset :
+        (Default value = 0.0)
+
+    Returns
+    -------
+
+
     """
     lineSegments = findSegments(sketch)[0]
     x0, y0, z0 = lineSegments[0]
@@ -604,7 +732,23 @@ def initialize_lithography(info, opts, fillShells=True):
 
 
 def gen_offset(opts, obj, offsetVal):
-    """Generates an offset non-destructively."""
+    """Generates an offset non-destructively.
+
+    Parameters
+    ----------
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    offsetVal :
+
+
+    Returns
+    -------
+
+
+    """
     doc = FreeCAD.ActiveDocument
     # First, we need to identify if we are working with a special part:
     my_part_label = None
@@ -668,6 +812,29 @@ def screened_H_union_list(info, opts, obj, m, j, offsetTuple, checkOffsetTuple):
     first whether the object intersects with the components of the checkOffset version
     of the H object. Then, for each component that would intersect, we return the a list
     of the offsetTuple version of the object.
+
+    Parameters
+    ----------
+    info :
+
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    m :
+
+    j :
+
+    offsetTuple :
+
+    checkOffsetTuple :
+
+
+    Returns
+    -------
+
+
     """
     logging.debug(">>> %s (%s)", obj.Name, obj.Label)
     # First, we need to check to see if we need to compute either of the
@@ -707,6 +874,29 @@ def screened_H_union_list(info, opts, obj, m, j, offsetTuple, checkOffsetTuple):
 def screened_A_UnionList(info, opts, obj, t, ti, offsetTuple, checkOffsetTuple):
     """Form the screened union list of obj with the substrate A that has
     been offset according to offsetTuple.
+
+    Parameters
+    ----------
+    info :
+
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    obj : FreeCAD.App.Document
+        A FreeCAD object.
+    t :
+
+    ti :
+
+    offsetTuple :
+
+    checkOffsetTuple :
+
+
+    Returns
+    -------
+
+
     """
     logging.debug(">>> %s (%s)", obj.Name, obj.Label)
     # First, we need to see if we have built the objects before:
@@ -744,6 +934,25 @@ def H_offset(info, opts, layer_num, objID, tList=[]):
 
     Note: this object is returned as a list of objects that need to be unioned together
     in order to form the full H.
+
+    Parameters
+    ----------
+    info :
+
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    layer_num :
+
+    objID :
+
+    tList :
+        (Default value = [])
+
+    Returns
+    -------
+
+
     """
 
     logging.debug(
@@ -810,6 +1019,20 @@ def gen_U(info, layer_num, objID):
     ```
     where the inner union terms are not included if their intersection
     with B_i is empty.
+
+    Parameters
+    ----------
+    info :
+
+    layer_num :
+
+    objID :
+
+
+    Returns
+    -------
+
+
     """
     layers = info.lithoDict["layers"]
     B = layers[layer_num]["objIDs"][objID]["B"]  # B prism for this layer & objID
@@ -832,7 +1055,25 @@ def gen_U(info, layer_num, objID):
 
 
 def gen_G(info, opts, layer_num, objID):
-    """Generate the gate deposition for a given layer_num and objID."""
+    """Generate the gate deposition for a given layer_num and objID.
+
+    Parameters
+    ----------
+    info :
+
+    opts : dict
+        Options dict in the QMT Geometry3D.__init__ input format.
+
+    layer_num :
+
+    objID :
+
+
+    Returns
+    -------
+
+
+    """
 
     layerobj = info.lithoDict["layers"][layer_num]["objIDs"][objID]
     logging.debug(
@@ -899,7 +1140,18 @@ def gen_G(info, opts, layer_num, objID):
 
 
 def collect_garbage(info):
-    """Delete all the objects in trash."""
+    """Delete all the objects in trash.
+
+    Parameters
+    ----------
+    info :
+
+
+    Returns
+    -------
+
+
+    """
     for obj in info.trash:
         try:
             delete(obj)
@@ -908,7 +1160,24 @@ def collect_garbage(info):
 
 
 def buildCrossSection(sliceName, axis, distance, built_parts_dict):
-    """Render the 2D objects required for cross-sections."""
+    """Render the 2D objects required for cross-sections.
+
+    Parameters
+    ----------
+    sliceName :
+
+    axis :
+
+    distance :
+
+    built_parts_dict : dict
+
+
+    Returns
+    -------
+
+
+    """
     polygons = {}
     for part_name in built_parts_dict:
         built_part = built_parts_dict[part_name]

--- a/qmt/geometry/freecad/sketchUtils.py
+++ b/qmt/geometry/freecad/sketchUtils.py
@@ -18,7 +18,19 @@ vec = FreeCAD.Vector
 
 def findSegments(sketch):
     """Return the line segments in a sketch as a numpy array.
-    Note: in FC0.17 sketches contain wires by default.
+
+    Parameters
+    ----------
+    sketch :
+
+
+    Returns
+    -------
+    A `np.ndarray` of line segments from `sketch`.
+
+    Notes
+    -----
+    In FC0.17 sketches contain wires by default.
     """
     lineSegments = []
     for wire in sketch.Shape.Wires:
@@ -31,14 +43,24 @@ def findSegments(sketch):
 
 def nextSegment(lineSegments, segIndex, tol=1e-8, fixOrder=True):
     """Return the next line segment index in a collection of tuples defining
-    several cycles.
-    WARNING: this will by default fixOrder, i.e. side effects on the caller.
+    several cycles. WARNING: this will by default fixOrder, i.e. side effects on
+    the caller.
 
-    Args:
-        lineSegments: ndarray with [lineSegmentIndex,start/end point,coordinate]
-        segIndex:     the index to consider
-        tol:          repair tolerance for matching
-        fixOrder:     whether the order lineSegments should be repaired on the fly
+    Parameters
+    ----------
+    lineSegments :
+        ndarray with [lineSegmentIndex,start/end point,coordinate]
+    segIndex :
+        the index to consider
+    tol :
+        repair tolerance for matching (Default value = 1e-8)
+    fixOrder :
+        whether the order lineSegments should be repaired on the fly (Default value = True)
+
+    Returns
+    -------
+    Line segment.
+
     """
     # initial end point - all other segment starts
     diffList0 = np.sum(
@@ -73,7 +95,20 @@ def nextSegment(lineSegments, segIndex, tol=1e-8, fixOrder=True):
 
 def findCycle(lineSegments, startingIndex, availSegIDs):
     """Find a cycle in a collection of line segments given a starting index.
-    Return the list of indices in the cycle.
+
+    Parameters
+    ----------
+    lineSegments :
+
+    startingIndex :
+
+    availSegIDs :
+
+
+    Returns
+    -------
+
+
     """
     currentIndex = startingIndex
     segList = [startingIndex]
@@ -100,7 +135,19 @@ def findCycle(lineSegments, startingIndex, availSegIDs):
 
 
 def addCycleSketch(name, wire):
-    """ Add a sketch of a cycle (closed wire) to a FC document.
+    """Add a sketch of a cycle (closed wire) to a FC document.
+
+    Parameters
+    ----------
+    name :
+
+    wire :
+
+
+    Returns
+    -------
+
+
     """
     assert wire.isClosed()
     doc = FreeCAD.ActiveDocument
@@ -129,7 +176,23 @@ def addCycleSketch(name, wire):
 
 
 def addPolyLineSketch(name, doc, segmentOrder, lineSegments):
-    """ Add a sketch given segment order and line segments
+    """Add a sketch given segment order and line segments.
+
+    Parameters
+    ----------
+    name :
+
+    doc :
+
+    segmentOrder :
+
+    lineSegments :
+
+
+    Returns
+    -------
+
+
     """
     if doc.getObject(name) is not None:
         raise ValueError(f"Sketch with name '{name}' already exists.")
@@ -147,7 +210,18 @@ def addPolyLineSketch(name, doc, segmentOrder, lineSegments):
 
 
 def findEdgeCycles(sketch):  # TODO: port objectConstruction crossection stuff
-    """Find the list of edges in a sketch and separate them into cycles."""
+    """Find the list of edges in a sketch and separate them into cycles.
+
+    Parameters
+    ----------
+    sketch :
+
+
+    Returns
+    -------
+
+
+    """
     lineSegments = findSegments(sketch)
     # Next, detect cycles:
     availSegIDs = range(lineSegments.shape[0])
@@ -163,12 +237,33 @@ def findEdgeCycles(sketch):  # TODO: port objectConstruction crossection stuff
 
 
 def findEdgeCycles2(sketch):
-    """Find the list of edges in a sketch and separate them into cycles."""
+    """Find the list of edges in a sketch and separate them into cycles.
+
+    Parameters
+    ----------
+    sketch :
+
+
+    Returns
+    -------
+
+
+    """
     return sketch.Shape.Wires
 
 
 def splitSketch(sketch):
     """Splits a sketch into several, returning a list of names of the new sketches.
+
+    Parameters
+    ----------
+    sketch :
+
+
+    Returns
+    -------
+
+
     """
     if not sketch.Shape.Wires:
         raise ValueError("No wires in sketch.")
@@ -179,8 +274,20 @@ def splitSketch(sketch):
 
 
 def extendSketch(sketch, d):
-    """ For a disconnected polyline, extends the last points of the sketch by 
-    a distance d. 
+    """For a disconnected polyline, extends the last points of the sketch by
+    a distance d.
+
+    Parameters
+    ----------
+    sketch :
+
+    d :
+
+
+    Returns
+    -------
+
+
     """
     doc = FreeCAD.ActiveDocument
     segments = findSegments(sketch)
@@ -238,7 +345,19 @@ def extendSketch(sketch, d):
 
 
 def makeIntoSketch(inputObj, sketchName=None):
-    """ Turn a 2D generic object like a polyline into a sketch.
+    """Turn a 2D generic object like a polyline into a sketch.
+
+    Parameters
+    ----------
+    inputObj :
+
+    sketchName :
+        (Default value = None)
+
+    Returns
+    -------
+
+
     """
     if sketchName is None:
         sketchName = inputObj.Name + "_sketch"

--- a/qmt/geometry/property_map.py
+++ b/qmt/geometry/property_map.py
@@ -1,11 +1,20 @@
 import numpy as np
 
 
-class PropertyMap(object):
+class PropertyMap:
     """Map points in the simulation domain to properties of parts containing the points.
 
-    :param PartMap part_map: Mapper from spatial location to part identifier.
-    :param callable prop_map: Map from part identifier to a property value.
+    Parameters
+    ----------
+    part_map : PartMap
+        Mapper from spatial location to part identifier.
+    prop_map : callable
+        Map from part identifier to a property value.
+
+    Returns
+    -------
+
+
     """
 
     def __init__(self, part_map, prop_map):
@@ -15,16 +24,30 @@ class PropertyMap(object):
     def get_part(self, x):
         """Find the part(s) containing one or more points.
 
-        :param x: Coordinate vector or array of coordinate vectors.
-        :return: Part identifier (if x is a single coordinate vector); or array of part identifiers, of the same shape as x except for the last axis corresponding to coordinate vector extent.
+        Parameters
+        ----------
+        x :
+            Coordinate vector or array of coordinate vectors.
+
+        Returns
+        -------
+
+
         """
         return self.partMap(x)
 
     def __call__(self, x):
         """Do the mapping.
 
-        :param x: Coordinate vector or array of coordinate vectors.
-        :return: Property of the part(s) containing `x`, of the same shape as `x` except for the last axis corresponding to coordinate vector extent.
+        Parameters
+        ----------
+        x :
+            Coordinate vector or array of coordinate vectors.
+
+        Returns
+        -------
+        Property of the part(s) containing `x`, of the same shape as `x` except for
+        the last axis corresponding to coordinate vector extent.
         """
         parts = self.get_part(x)
         if np.isscalar(parts):
@@ -47,12 +70,25 @@ class PropertyMap(object):
 class MaterialPropertyMap(PropertyMap):
     """Map points in the simulation domain to material properties of parts containing the points.
 
-    :param PartMap part_map: Function that takes a spatial location and maps it to a part identifier.
-    :param dict part_materials: Dict mapping from part identifier to a material name.
-    :param qmt.Materials mat_lib: Materials library used to look up the material properties.
-    :param str prop_name: Name of the material property to be retrieved for each part.
-    :param eunit: Energy unit, passed to `mat_lib.find()`.
-    :param fill_value: Value to be filled in places where there is no part or the part does not have a material or the material does not have the property `prop_name`. The default behavior `fill_value='raise'` is to raise a KeyError in these cases.
+    Parameters
+    ----------
+    part_map : PartMap
+        Function that takes a spatial location and maps it to a part identifier.
+    part_materials : dict
+        Dict mapping from part identifier to a material name.
+    mat_lib : qmt.Materials
+        Materials library used to look up the material properties.
+    str :
+        prop_name: Name of the material property to be retrieved for each part.
+    eunit :
+        Energy unit, passed to `mat_lib.find()`.
+    fill_value :
+        Value to be filled in places where there is no part or the part does not have a material or the material does not have the property `prop_name`. The default behavior `fill_value='raise'` is to raise a KeyError in these cases.
+
+    Returns
+    -------
+
+
     """
 
     def __init__(

--- a/qmt/materials.py
+++ b/qmt/materials.py
@@ -34,13 +34,18 @@ class Material(collections.Mapping):
     Allows for the retrieval of a material's properties. Adds units awareness on top of a plain
     dict containing the properties.
 
-    :param str name: Material name.
-    :param dict properties: Collection of material properties.
-    :param str eunit:
+    Parameters
+    ----------
+    name : str
+        Material name.
+    properties : dict
+        Collection of material properties.
+    eunit : str
         Unit of energy. If specified, all queries for band parameters
         that have the dimension of an energy return floats with respect
         to this energy unit. With the default (None), such queries
         return sympy quantities that have the dimension of an energy.
+
     """
 
     def __init__(self, name, properties, eunit=None):
@@ -98,11 +103,20 @@ class Material(collections.Mapping):
     def hole_mass(self, band, direction):
         """Determine effective mass for a valence band.
 
-        :param str band: Which valence band: 'heavy' or 'light' for a specific band. Also 'dos' for
+        Parameters
+        ----------
+        ban : str
+            Which valence band: 'heavy' or 'light' for a specific band. Also 'dos' for
             a density-of-states mass corresponding to both bands.
-        :param str direction: Momentum direction: One of '001', '110', or '111'. 'z' is equivalent
+        direction : str
+            Momentum direction: One of '001', '110', or '111'. 'z' is equivalent
             to '001'. Can also be 'dos' for the scalar density-of-states mass of a corresponding
             isotropic band dispersion.
+
+        Returns
+        -------
+
+
         """
         # DOS effective mass corresponding to both heavy and light hole band
         # [Lax and Mavroides (1955) Eq. 17]
@@ -166,13 +180,16 @@ class Materials(collections.Mapping):
     materials.json and loads it. If both matPath and matDict are specified, the Materials
     database is initialized from the given path and then updated with the supplied dict.
 
-    :param str matPath:
+    Parameters
+    ----------
+    matPath : str
         Path to the mat json file. If initialized with None, should be set
         manually before loading/saving.
-    :param dict matDict:
+    matDict : dict
         Dictionary of materials to fill the database.
-    :param Bool load:
+    load : bool
         Load the json file. Needs to be False when creating a new materials.json file.
+
     """
 
     def __init__(self, matPath=None, matDict=None, load=True):
@@ -197,13 +214,44 @@ class Materials(collections.Mapping):
 
     def add_material(self, name, mat_type, **kwargs):
         """Generate a material and add it to the matDict.
+
+        Parameters
+        ----------
+        name :
+
+        mat_type :
+
+        **kwargs :
+
+
+        Returns
+        -------
+
+
         """
         if mat_type in ("metal", "dielectric"):
             kwargs["electronMass"] = kwargs.get("electronMass", 1.0)
         self.matDict[name] = self._make_material(mat_type, **kwargs)
 
     def set_bowing_parameters(self, name_a, name_b, mat_type, **kwargs):
-        """Generate a bowing parameter set and add it to the bowingParameters dict."""
+        """Generate a bowing parameter set and add it to the bowingParameters dict.
+
+        Parameters
+        ----------
+        name_a :
+
+        name_b :
+
+        mat_type :
+
+        **kwargs :
+
+
+        Returns
+        -------
+
+
+        """
         self.bowingParameters[(name_a, name_b)] = self._make_material(
             mat_type, **kwargs
         )
@@ -262,10 +310,18 @@ class Materials(collections.Mapping):
         If the material is not found directly, an attempt is made to construct
         it by mixing two known materials. If that also fails, a KeyError is raised.
 
-        :param str name:
+        Parameters
+        ----------
+        name : str
             Name of the desired material.
-        :param str eunit:
+        eunit : str
             Unit of energy. This is passed on to the Material constructor.
+            (Default value = None)
+
+        Returns
+        -------
+        Material instance.
+
         """
         if name in self.matDict:
             properties = self.matDict[name]
@@ -316,6 +372,20 @@ class Materials(collections.Mapping):
         uses the convention
             O(A_{1-x} B_x) = (1-x) O(A) + x O(B) - x(1-x) O_{AB} ,
         with the bowing parameter O_{AB}.
+
+        Parameters
+        ----------
+        nameA :
+
+        nameB :
+
+        x :
+
+
+        Returns
+        -------
+
+
         """
         assert x >= 0 and x <= 1
         if (nameB, nameA) in self.bowingParameters:
@@ -353,15 +423,13 @@ class Materials(collections.Mapping):
             self.bowingParameters[literal_eval(k)] = v
 
     def save(self):
-        """Save the current materials database to disk.
-        """
+        """Save the current materials database to disk."""
         db = self.serialize_dict()
         with open(self.matPath, "w") as myFile:
             json.dump(db, myFile, indent=4, sort_keys=True)
 
     def load(self):
-        """Load the materials database from disk.
-        """
+        """Load the materials database from disk."""
         try:
             with open(self.matPath, "r") as myFile:
                 db = json.load(myFile)
@@ -385,15 +453,21 @@ class Materials(collections.Mapping):
         If the material's valenceBandOffset is not known, we return `-mat[electronAffinity]`,
         effectively falling back on Anderson's rule.
 
-        :param Material mat:
+        Parameters
+        ----------
+        mat: Material instance
             Material whose conduction band position is to be determined.
+
+        Returns
+        -------
 
         See also
         --------
         - valence_band_maximum(mat) is equivalent to
-          `self.conduction_band_minimum(mat) - mat['directBandGap']`
+        `self.conduction_band_minimum(mat) - mat['directBandGap']`
         - conduction_band_offset(mat1, mat2) is equivalent to
-          `self.conduction_band_minimum(mat1) - self.conduction_band_minimum(mat2)`
+        `self.conduction_band_minimum(mat1) - self.conduction_band_minimum(mat2)`
+                mat :
         """
         ref_name = "InSb"
         if mat["type"] == "metal":
@@ -438,15 +512,21 @@ class Materials(collections.Mapping):
         The reference energy E=0 is fixed to the vacuum level, as defined by the electron affinity
         of InSb. See conduction_band_minimum for additional details.
 
-        :param Material mat:
+        Parameters
+        ----------
+        mat : Material
             Material whose valence band position is to be determined.
+
+        Returns
+        -------
 
         See also
         --------
         - conduction_band_minimum(mat) is equivalent to
-          `self.valence_band_maximum(mat) + mat['directBandGap']`
+        `self.valence_band_maximum(mat) + mat['directBandGap']`
         - valence_band_offset(mat1, mat2) is equivalent to
-          `self.valence_band_maximum(mat1) - self.valence_band_maximum(mat2)`
+        `self.valence_band_maximum(mat1) - self.valence_band_maximum(mat2)`
+                mat :
         """
         if mat["type"] == "metal":
             return -10.0e3 * mat.energyUnit  # very low
@@ -493,13 +573,19 @@ class Materials(collections.Mapping):
 
 
 def conduction_band_offset(mat, ref_mat):
-    """
-    Calculate the conduction band offset $E_c - E_{c,ref}$ between two semiconductor materials.
+    """Calculate the conduction band offset $E_c - E_{c,ref}$ between two semiconductor materials.
 
-    :param Material mat:
+    Parameters
+    ----------
+    mat : Material
         Material whose conduction band position is to be determined.
-    :param Material ref_mat:
+    ref_mat : Material
         Material whose conduction band minimum is used as reference energy.
+
+    Returns
+    -------
+
+
     """
     assert mat.energyUnit == ref_mat.energyUnit
     try:
@@ -525,13 +611,19 @@ def conduction_band_offset(mat, ref_mat):
 
 
 def valence_band_offset(mat, ref_mat):
-    """
-    Calculate the valence band offset $E_v - E_{v,ref}$ between two semiconductor materials.
+    """Calculate the valence band offset $E_v - E_{v,ref}$ between two semiconductor materials.
 
-    :param Material mat:
+    Parameters
+    ----------
+    mat : Material
         Material whose conduction band position is to be determined.
-    :param Material ref_mat:
+    ref_mat : Material
         Material whose conduction band minimum is used as reference energy.
+
+    Returns
+    -------
+
+
     """
     assert mat.energyUnit == ref_mat.energyUnit
     try:
@@ -552,11 +644,19 @@ def valence_band_offset(mat, ref_mat):
 
 
 def write_database_to_markdown(out_file, mat_lib):
-    """
-    Write all materials parameters in mat_lib to a nicely formatted markdown file.
+    """Write all materials parameters in mat_lib to a nicely formatted markdown file.
 
-    :param stream out_file: Output file handle.
-    :param Materials mat_lib: Materials database to be written.
+    Parameters
+    ----------
+    out_file : stream
+        Output file handle.
+    mat_lib : Materials
+        Materials database to be written.
+
+    Returns
+    -------
+
+
     """
     import pytablewriter
 

--- a/qmt/physics_constants.py
+++ b/qmt/physics_constants.py
@@ -36,7 +36,18 @@ units = SimpleNamespace(
 
 
 def parse_unit(s):
-    """convert name of a unit into the corresponding sympy value"""
+    """convert name of a unit into the corresponding sympy value
+
+    Parameters
+    ----------
+    s :
+
+
+    Returns
+    -------
+
+
+    """
     for u in dir(units):
         if u[:2] == "__":
             continue
@@ -64,7 +75,20 @@ constants = SimpleNamespace(
 if "convert_to" in dir(spu):
 
     def canonicalize(expr, base=None):
-        """Convert all units to given base units (default: SI base units)"""
+        """Convert all units to given base units (default: SI base units)
+
+        Parameters
+        ----------
+        expr :
+
+        base :
+            (Default value = None)
+
+        Returns
+        -------
+
+
+        """
         if base is None:
             base = (spu.m, spu.kg, spu.s, spu.A, spu.K, spu.mol, spu.cd)
         return spu.convert_to(expr, base)
@@ -77,16 +101,34 @@ else:
 
 
 def cancel(expr):
-    """
-    Cancel different units referring to the same dimension, e.g. cancel(kg/g) -> 1000
+    """Cancel different units referring to the same dimension, e.g. cancel(kg/g) -> 1000
+
+    Parameters
+    ----------
+    expr :
+
+
+    Returns
+    -------
+
+
     """
     return canonicalize(expr, 1)
 
 
 def to_float(expr):
-    """
-    Convert sympy expression involving units to a float. Fails if expr is not
+    """Convert sympy expression involving units to a float. Fails if expr is not
     dimensionless.
+
+    Parameters
+    ----------
+    expr :
+
+
+    Returns
+    -------
+
+
     """
     return float(cancel(expr))
 
@@ -115,9 +157,16 @@ matrices.tau_zz = kron(matrices.s_z, matrices.s_z)
 
 
 class UArray(np.ndarray):
-    """
-    Extend a numpy array to have units information from sympy
+    """Extend a numpy array to have units information from sympy
     From https://docs.scipy.org/doc/numpy/user/basics.subclassing.html#simple-example-adding-an-extra-attribute-to-ndarray
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+
     """
 
     def __new__(cls, input_array, unit=None):

--- a/qmt/tasks/geometry.py
+++ b/qmt/tasks/geometry.py
@@ -9,18 +9,30 @@ import FreeCAD
 
 
 def build_2d_geometry(parts, edges, lunit="nm", build_order=None):
-    """
-    Build a geometry in 2D.
+    """Build a geometry in 2D.
 
-    :param dict parts: Dictionary for holding the 2D parts, of the form
-                       {'part_name':list of 2d points}.
-    :param dict edges: Dictionary of 2D edges, of the form:
-                       {'edge_name':list of 2d points}.
-    :param str lunit: length_unit (nm).
-    :param list build_order: None or a list of all parts, determining the build order. Items on
-                             the left are highest priority and items on the right are lowest.
-                             If None is given (default), then build order is determined just
-                             taken to be the order of the parts and edges.
+    Parameters
+    ----------
+    parts : dict
+        Dictionary for holding the 2D parts, of the form
+        {'part_name':list of 2d points}.
+    edges : dict
+        Dictionary of 2D edges, of the form:
+        {'edge_name':list of 2d points}.
+    lunit : str
+        length_unit (nm).
+        (Default value = "nm")
+    build_order : list
+        None or a list of all parts, determining the build order. Items on
+        the left are highest priority and items on the right are lowest.
+        If None is given (default), then build order is determined just
+        taken to be the order of the parts and edges.
+        (Default value = None)
+
+    Returns
+    -------
+    Geo2DData instance
+
     """
     geo_2d = Geo2DData()
     if build_order is None:
@@ -53,23 +65,37 @@ def build_3d_geometry(
     serialized_input_file=None,
     params=None,
 ):
-    """
-    Build a geometry in 3D.
+    """Build a geometry in 3D.
 
-    :param list input_parts: Ordered list of input parts, leftmost items get built first
-    :param str input_file: Path to FreeCAD template file. Either this or serialized_input_file
+    Parameters
+    ----------
+    input_parts : list
+        Ordered list of input parts, leftmost items get built first
+    input_file : str
+        Path to FreeCAD template file. Either this or serialized_input_file
         must be set (but not both).
-    :param dict xsec_dict: Dictionary of cross-section specifications. It should be of the
+        (Default value = None)
+    xsec_dict : dict
+        Dictionary of cross-section specifications. It should be of the
         form {'xsec_name':{'axis':(1,0,0),'distance':0.}}, where the axis parameter is a tuple
         defining the axis that defines the normal of the cross section, and distance is
         the length along the axis used to set the cross section.
-    :param bytes serialized_input_file: FreeCAD template file that has been serialized using
+        (Default value = None)
+    serialized_input_file : bytes
+        FreeCAD template file that has been serialized using
         qmt.data.serialize_file. This is useful for passing a
         file into a docker container or other environment that
         doesn't have access to a shared drive. Either this or
         serialized_input_file must be set (but not both).
-    :param dict params: Dictionary of parameters to use in FreeCAD.
-    :return Geo3DData: A built geometry.
+        (Default value = None)
+    params : dict
+        Dictionary of parameters to use in FreeCAD.
+        (Default value = None)
+
+    Returns
+    -------
+    built
+
     """
     if input_file is None and serialized_input_file is None:
         raise ValueError("One of input_file or serialized_input_file must be non-none.")

--- a/tests/test_freecad_objectConstruction.py
+++ b/tests/test_freecad_objectConstruction.py
@@ -58,7 +58,7 @@ def test_makeSAG(fix_FCDoc, fix_rectangle_sketch):
         /    \
        /      \
       /        \        NOT TO SCALE
-     /          \ 
+     /          \
     /_          _\
       |________|
     """
@@ -78,7 +78,7 @@ def test_makeSAG_offset(fix_FCDoc, fix_rectangle_sketch):
         //  \\
        //    \\
       //      \\        NOT TO SCALE
-     //_      _\\ 
+     //_      _\\
     /__ |    | __\
        ||____||
        |______|
@@ -95,13 +95,13 @@ def test_makeSAG_offset(fix_FCDoc, fix_rectangle_sketch):
 
 def test_makeSAG_triangle_with_rectangular_base(fix_FCDoc, fix_rectangle_sketch):
     r"""
-    Test the case where the top collapses down to a line 
+    Test the case where the top collapses down to a line
           /\
          /  \
         /    \
        /      \        NOT TO SCALE
       /        \
-     /          \ 
+     /          \
     /_          _\
       |________|
     """
@@ -116,13 +116,13 @@ def test_makeSAG_triangle_with_rectangular_base(fix_FCDoc, fix_rectangle_sketch)
 
 def test_makeSAG_triangle_with_square_base(fix_FCDoc, fix_rectangle_sketch):
     r"""
-    Test the case where the top collapses down to a point 
+    Test the case where the top collapses down to a point
           /\
          /  \
         /    \
        /      \        NOT TO SCALE
       /        \
-     /          \ 
+     /          \
     /_          _\
       |________|
     """
@@ -142,7 +142,7 @@ def test_makeSAG_triangle_with_no_rectangular_part(fix_FCDoc, fix_rectangle_sket
         /    \
        /      \        NOT TO SCALE
       /        \
-     /          \ 
+     /          \
     /____________\
     """
     sketch = fix_rectangle_sketch()


### PR DESCRIPTION
Currently, the docstrings do not have any particular standard or style (to the best of my knowledge). 

I think the intention was to use standard Python reST style docstrings, however, they were not correct.

Besides that, those docstrings are very hard to read (and also hard to write). I propose to use NumPy style docstrings, which is the standard in almost all scientific packages.

~~Using this (a) standard, it is easy to create API documentation using Sphinx, see for example the documentation [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html#scipy.interpolate.interp1d) which is generated by this [source](https://github.com/scipy/scipy/blob/v1.2.1/scipy/interpolate/interpolate.py#L345-L701).~~
edit: I see that there is already documentation! And I am surprised that it was smart enough to create it from the old docstrings.

The doc-strings are not complete, but I left empty space to fill in the missing information.

@johnkgamble and @likewei92 what do you think?