### PR TITLE
run pyupgrade --py36-plus

### DIFF
--- a/qmt/_version.py
+++ b/qmt/_version.py
@@ -53,7 +53,7 @@ def pep440_format(version_info):
         if release.endswith("-dev") or release.endswith(".dev"):
             version_parts.append(dev)
         else:  # prefer PEP440 over strict adhesion to semver
-            version_parts.append(".dev{}".format(dev))
+            version_parts.append(f".dev{dev}")
 
     if labels:
         version_parts.append("+")
@@ -150,13 +150,13 @@ def get_version_from_git_archive(version_info):
         return None
 
     VTAG = "tag: v"
-    refs = set(r.strip() for r in refnames.split(","))
-    version_tags = set(r[len(VTAG) :] for r in refs if r.startswith(VTAG))
+    refs = {r.strip() for r in refnames.split(",")}
+    version_tags = {r[len(VTAG) :] for r in refs if r.startswith(VTAG)}
     if version_tags:
         release, *_ = sorted(version_tags)  # prefer e.g. "2.0" over "2.0rc1"
         return Version(release, dev=None, labels=None)
     else:
-        return Version("unknown", dev=None, labels=["g{}".format(git_hash)])
+        return Version("unknown", dev=None, labels=[f"g{git_hash}"])
 
 
 __version__ = get_version()

--- a/qmt/geometry/freecad/objectConstruction.py
+++ b/qmt/geometry/freecad/objectConstruction.py
@@ -922,7 +922,7 @@ def screened_A_UnionList(info, opts, obj, t, ti, offsetTuple, checkOffsetTuple):
 
 
 def H_offset(info, opts, layer_num, objID, tList=[]):
-    """For a given layer_num=n and ObjID=i, compute the deposited object.
+    r"""For a given layer_num=n and ObjID=i, compute the deposited object.
 
     ```latex
     H_{n,i}(t) = C_{n,i}(t) \cap [ B_{n,i}(t) \cup (\cup_{m<n;j} H_{m,j}(t_i+t)) \cup (\cup_k A_k(t_i + t))],
@@ -1012,7 +1012,7 @@ def H_offset(info, opts, layer_num, objID, tList=[]):
 
 
 def gen_U(info, layer_num, objID):
-    """For a given layer_num and objID, compute the quantity:
+    r"""For a given layer_num and objID, compute the quantity:
     ```latex
     U_{n,i}(t) = (\cup_{m<n;j} G_{m,j}) \cup (\cup_{k} A_k),
     ```

--- a/qmt/geometry/property_map.py
+++ b/qmt/geometry/property_map.py
@@ -101,9 +101,9 @@ class MaterialPropertyMap(PropertyMap):
         fill_value="raise",
     ):
         self.fillValue = fill_value
-        self.materialsDict = dict(
-            (p, mat_lib.find(m, eunit)) for p, m in part_materials.items()
-        )
+        self.materialsDict = {
+            p: mat_lib.find(m, eunit) for p, m in part_materials.items()
+        }
 
         self.partProps = {}
         for p, mat in self.materialsDict.items():
@@ -131,4 +131,4 @@ class MaterialPropertyMap(PropertyMap):
                     raise
                 return self.fillValue
 
-        super(MaterialPropertyMap, self).__init__(part_map, prop_map)
+        super().__init__(part_map, prop_map)

--- a/qmt/materials/materials.py
+++ b/qmt/materials/materials.py
@@ -67,7 +67,7 @@ class Material(collections.Mapping):
         try:
             value = self.properties[key]
         except KeyError:
-            raise KeyError("KeyError: material '{}' has no '{}'".format(self.name, key))
+            raise KeyError(f"KeyError: material '{self.name}' has no '{key}'")
         if key in self.energy_quantities:
             value *= self.energyUnit
         return value
@@ -129,7 +129,7 @@ class Material(collections.Mapping):
         elif band == "light":
             sign = 1
         else:
-            raise RuntimeError("invalid band: {}".format(band))
+            raise RuntimeError(f"invalid band: {band}")
 
         # DOS effective mass corresponding to anisotropic (possibly warped) band.
         # [We use the expansion from Lax and Mavroides (1955) Eq. 15;
@@ -772,8 +772,8 @@ def write_database_to_markdown(out_file, mat_lib):
         ),
         file=out_file,
     )
-    scale_factors = dict(
-        (p, 1e-3)
+    scale_factors = {
+        p: 1e-3
         for p in (
             "workFunction",
             "fermiEnergy",
@@ -784,7 +784,7 @@ def write_database_to_markdown(out_file, mat_lib):
             "interbandMatrixElement",
             "spinOrbitSplitting",
         )
-    )
+    }
     table = []
     bowing_mats = sorted(mat_lib.bowingParameters.keys())
     bowing_props = []

--- a/qmt/materials/materials.py
+++ b/qmt/materials/materials.py
@@ -123,7 +123,7 @@ class Material(collections.Mapping):
             ) ** (2 / 3.0)
 
         # Retrieve Luttinger parameters
-        gamma1, gamma2, gamma3 = (self["luttingerGamma%s" % i] for i in (1, 2, 3))
+        gamma1, gamma2, gamma3 = (self[f"luttingerGamma{i}"] for i in (1, 2, 3))
         if band == "heavy":
             sign = -1
         elif band == "light":
@@ -431,7 +431,7 @@ class Materials(collections.Mapping):
                 db = json.load(myFile)
             self.deserialize_dict(db)
         except IOError:
-            print("Could not load materials file %s." % self.matPath)
+            print(f"Could not load materials file {self.matPath}.")
             print("Generating a new file at that location...")
             generate_file(self.matPath)
             self.load()

--- a/qmt/physics_constants.py
+++ b/qmt/physics_constants.py
@@ -57,7 +57,7 @@ def parse_unit(s):
     # through
     if hasattr(s, "subs"):
         return s
-    raise RuntimeError("unknown unit: {}".format(s))
+    raise RuntimeError(f"unknown unit: {s}")
 
 
 constants = SimpleNamespace(
@@ -190,7 +190,7 @@ class UArray(np.ndarray):
 
     def __reduce__(self):
         # Get the parent's __reduce__ tuple
-        pickled_state = super(UArray, self).__reduce__()
+        pickled_state = super().__reduce__()
         # Create our own tuple to pass to __setstate__
         new_state = pickled_state[2] + (self.unit,)
         # Return a tuple that replaces the parent's __setstate__ tuple with our own
@@ -199,7 +199,7 @@ class UArray(np.ndarray):
     def __setstate__(self, state):
         self.unit = state[-1]  # Set the unit attribute
         # Call the parent's __setstate__ with the other tuple elements.
-        super(UArray, self).__setstate__(state[0:-1])
+        super().__setstate__(state[0:-1])
 
 
 __all__ = ["units", "constants", "matrices", "parse_unit", "to_float", "UArray"]


### PR DESCRIPTION
I just discovered `pyupgrade` which can convert the syntax to newly recommended ways of newer Python versions.

